### PR TITLE
Unblock more methods by leaving unmarked tail calls as calls

### DIFF
--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 
@@ -3482,11 +6765,46 @@ entry:
 }
 
 INFO:  jitting method BringUpTest::Call1 using LLILCJit
-Failed to read BringUpTest.Call1[Tail call]
+Successfully read BringUpTest.Call1
+
+define void @BringUpTest.Call1() {
+entry:
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+}
+
 INFO:  jitting method BringUpTest::M using LLILCJit
-Failed to read BringUpTest.M[Tail call]
+Successfully read BringUpTest.M
+
+define void @BringUpTest.M() {
+entry:
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  ret void
+}
+
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 104
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3503,7 +6821,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3701,11 +7055,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3721,9 +7154,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3817,7 +7280,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3862,7 +7371,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3909,11 +7530,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3936,7 +7645,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3984,7 +7703,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4011,9 +7741,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4159,7 +7997,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4175,11 +8034,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4267,19 +8271,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4306,7 +8297,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4351,7 +8371,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4458,7 +8677,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4510,7 +8729,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4542,9 +8806,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4599,20 +8909,208 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Failed to read TextWriter.WriteLine[loadElem]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32, i32* %arg3
+  %17 = icmp sge i32 %16, 0
+  br i1 %17, label %23, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %20)
+  %22 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22, %System.String addrspace(1)* %19, %System.String addrspace(1)* %21)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22) #0
+  unreachable
+
+; <label>:23                                      ; preds = %15
+  %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %37, label %33
+
+; <label>:33                                      ; preds = %23
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
+  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+  unreachable
+
+; <label>:37                                      ; preds = %23
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
+  br label %89
+
+; <label>:39                                      ; preds = %89
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = icmp ne i32 %42, %45
+  br i1 %46, label %49, label %47
+
+; <label>:47                                      ; preds = %39
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
+  br label %49
+
+; <label>:49                                      ; preds = %39, %47
+  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
+  %52 = load i32, i32 addrspace(1)* %51, align 8
+  %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = sub i32 %52, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc0
+  %58 = load i32, i32* %arg3
+  %59 = icmp sle i32 %57, %58
+  br i1 %59, label %62, label %60
+
+; <label>:60                                      ; preds = %49
+  %61 = load i32, i32* %arg3
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %49, %60
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %64 = load i32, i32* %arg2
+  %65 = mul i32 %64, 2
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
+  %71 = load i32, i32 addrspace(1)* %70, align 8
+  %72 = mul i32 %71, 2
+  %73 = load i32, i32* %loc0
+  %74 = mul i32 %73, 2
+  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
+  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load i32, i32* %loc0
+  %81 = add i32 %79, %80
+  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  store i32 %81, i32 addrspace(1)* %82
+  %83 = load i32, i32* %arg2
+  %84 = load i32, i32* %loc0
+  %85 = add i32 %83, %84
+  store i32 %85, i32* %arg2
+  %86 = load i32, i32* %arg3
+  %87 = load i32, i32* %loc0
+  %88 = sub i32 %86, %87
+  store i32 %88, i32* %arg3
+  br label %89
+
+; <label>:89                                      ; preds = %37, %62
+  %90 = load i32, i32* %arg3
+  %91 = icmp sgt i32 %90, 0
+  br i1 %91, label %39, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
+  %95 = load i8, i8 addrspace(1)* %94, align 8
+  %96 = zext i8 %95 to i32
+  %97 = icmp eq i32 %96, 0
+  br i1 %97, label %100, label %98
+
+; <label>:98                                      ; preds = %92
+  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
+  br label %100
+
+; <label>:100                                     ; preds = %92, %98
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -4621,7 +9119,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -4760,5 +9370,62 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblAdd using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblAddConst using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,9 +10028,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,15 +6737,86 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblArea using LLILCJit
-Failed to read BringUpTest.DblArea[Tail call]
+Successfully read BringUpTest.DblArea
+
+define double @BringUpTest.DblArea(double %param0, double %param1, double %param2) {
+entry:
+  %arg0 = alloca double
+  %arg1 = alloca double
+  %arg2 = alloca double
+  %loc0 = alloca double
+  store double %param0, double* %arg0
+  store double %param1, double* %arg1
+  store double %param2, double* %arg2
+  %0 = load double, double* %arg0
+  %1 = load double, double* %arg1
+  %2 = fadd double %0, %1
+  %3 = load double, double* %arg2
+  %4 = fadd double %2, %3
+  %5 = fdiv double %4, 2.000000e+00
+  store double %5, double* %loc0
+  %6 = load double, double* %loc0
+  %7 = load double, double* %loc0
+  %8 = load double, double* %arg0
+  %9 = fsub double %7, %8
+  %10 = fmul double %6, %9
+  %11 = load double, double* %loc0
+  %12 = load double, double* %arg1
+  %13 = fsub double %11, %12
+  %14 = fmul double %10, %13
+  %15 = load double, double* %loc0
+  %16 = load double, double* %arg2
+  %17 = fsub double %15, %16
+  %18 = fmul double %14, %17
+  %19 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (double)*)(double %18)
+  ret double %19
+}
+
 INFO:  jitting method BringUpTest::DblSqrt using LLILCJit
 Failed to read BringUpTest.DblSqrt[sqrt]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3496,7 +6833,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3694,11 +7067,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3714,9 +7166,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3810,7 +7292,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3855,7 +7383,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3902,11 +7542,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3929,7 +7657,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3977,7 +7715,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4004,9 +7753,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4152,7 +8009,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4168,11 +8046,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4260,19 +8283,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4299,7 +8309,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4344,7 +8383,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4451,7 +8689,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4503,7 +8741,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4535,9 +8818,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4592,11 +8921,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4866,17 +9281,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4912,7 +9325,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5217,18 +9646,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5237,7 +9803,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5376,9 +10054,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,13 +6737,50 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertHandle]
 INFO:  jitting method BringUpTest::DblArray using LLILCJit
 Failed to read BringUpTest.DblArray[loadElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3494,7 +6797,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3692,11 +7031,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3712,9 +7130,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3808,7 +7256,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3853,7 +7347,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3900,11 +7506,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3927,7 +7621,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3975,7 +7679,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4002,9 +7717,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4150,7 +7973,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4166,11 +8010,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4258,19 +8247,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4297,7 +8273,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4342,7 +8347,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4449,7 +8653,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4501,7 +8705,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4533,9 +8782,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4590,11 +8885,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4864,17 +9245,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4910,7 +9289,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5215,18 +9610,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5235,7 +9767,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5374,9 +10018,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblAvg2 using LLILCJit
@@ -3494,7 +6777,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3511,7 +6814,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3709,11 +7048,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3729,9 +7147,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3825,7 +7273,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3870,7 +7364,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3917,11 +7523,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3944,7 +7638,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3992,7 +7696,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4019,9 +7734,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4167,7 +7990,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4183,11 +8027,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4275,19 +8264,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4314,7 +8290,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4359,7 +8364,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4466,7 +8670,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4518,7 +8722,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4550,9 +8799,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4607,11 +8902,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4881,17 +9262,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4927,7 +9306,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5232,18 +9627,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5252,7 +9784,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5391,9 +10035,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblAvg6 using LLILCJit
@@ -3510,7 +6793,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3527,7 +6830,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3725,11 +7064,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3745,9 +7163,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3841,7 +7289,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3886,7 +7380,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3933,11 +7539,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3960,7 +7654,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4008,7 +7712,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4035,9 +7750,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4183,7 +8006,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4199,11 +8043,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4291,19 +8280,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4330,7 +8306,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4375,7 +8380,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4482,7 +8686,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4534,7 +8738,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4566,9 +8815,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4623,11 +8918,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4897,17 +9278,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4943,7 +9322,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5248,18 +9643,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5268,7 +9800,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5407,9 +10051,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblCall1 using LLILCJit
@@ -3507,7 +6790,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3524,7 +6827,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3722,11 +7061,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3742,9 +7160,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3838,7 +7286,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3883,7 +7377,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3930,11 +7536,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3957,7 +7651,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4005,7 +7709,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4032,9 +7747,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4180,7 +8003,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4196,11 +8040,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4288,19 +8277,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4327,7 +8303,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4372,7 +8377,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4479,7 +8683,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4531,7 +8735,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4563,9 +8812,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4620,11 +8915,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4894,17 +9275,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4940,7 +9319,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5245,18 +9640,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5265,7 +9797,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5404,9 +10048,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,11 +6737,49 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblCall2 using LLILCJit
-Failed to read BringUpTest.DblCall2[Tail call]
+Successfully read BringUpTest.DblCall2
+
+define double @BringUpTest.DblCall2(double %param0, double %param1, double %param2, double %param3) {
+entry:
+  %arg0 = alloca double
+  %arg1 = alloca double
+  %arg2 = alloca double
+  %arg3 = alloca double
+  store double %param0, double* %arg0
+  store double %param1, double* %arg1
+  store double %param2, double* %arg2
+  store double %param3, double* %arg3
+  %0 = load double, double* %arg0
+  %1 = load double, double* %arg1
+  %2 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (double, double)*)(double %0, double %1)
+  %3 = load double, double* %arg2
+  %4 = load double, double* %arg3
+  %5 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (double, double)*)(double %3, double %4)
+  %6 = call double inttoptr (i64 NORMALIZED_ADDRESS to double (double, double)*)(double %2, double %5)
+  ret double %6
+}
+
 INFO:  jitting method BringUpTest::DblAvg2 using LLILCJit
 Successfully read BringUpTest.DblAvg2
 
@@ -3496,7 +6800,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3513,7 +6837,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3711,11 +7071,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3731,9 +7170,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3827,7 +7296,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3872,7 +7387,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3919,11 +7546,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3946,7 +7661,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3994,7 +7719,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4021,9 +7757,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4169,7 +8013,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4185,11 +8050,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4277,19 +8287,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4316,7 +8313,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4361,7 +8387,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4468,7 +8693,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4520,7 +8745,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4552,9 +8822,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4609,11 +8925,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4883,17 +9285,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4929,7 +9329,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5234,18 +9650,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5254,7 +9807,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5393,9 +10058,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblDist using LLILCJit
@@ -3512,7 +6795,27 @@ entry:
 INFO:  jitting method BringUpTest::sqrt using LLILCJit
 Failed to read BringUpTest.sqrt[sqrt]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3529,7 +6832,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3727,11 +7066,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3747,9 +7165,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3843,7 +7291,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3888,7 +7382,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3935,11 +7541,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3962,7 +7656,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4010,7 +7714,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4037,9 +7752,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4185,7 +8008,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4201,11 +8045,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4293,19 +8282,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4332,7 +8308,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4377,7 +8382,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4484,7 +8688,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4536,7 +8740,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4568,9 +8817,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4625,11 +8920,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4899,17 +9280,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4945,7 +9324,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5250,18 +9645,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5270,7 +9802,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5409,9 +10053,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblDiv using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblDivConst using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,9 +10028,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblFillArray using LLILCJit
@@ -3479,7 +6762,27 @@ Failed to read BringUpTest.DblFillArray[storeElem]
 INFO:  jitting method BringUpTest::DblArray using LLILCJit
 Failed to read BringUpTest.DblArray[loadElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3496,7 +6799,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3694,11 +7033,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3714,9 +7132,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3810,7 +7258,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3855,7 +7349,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3902,11 +7508,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3929,7 +7623,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3977,7 +7681,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4004,9 +7719,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4152,7 +7975,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4168,11 +8012,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4260,19 +8249,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4299,7 +8275,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4344,7 +8349,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4451,7 +8655,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4503,7 +8707,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4535,9 +8784,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4592,11 +8887,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4866,17 +9247,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4912,7 +9291,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5217,18 +9612,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5237,7 +9769,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5376,9 +10020,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblMul using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblMulConst using LLILCJit
@@ -3489,7 +6772,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3506,7 +6809,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3704,11 +7043,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3724,9 +7142,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3820,7 +7268,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3865,7 +7359,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3912,11 +7518,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3939,7 +7633,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3987,7 +7691,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4014,9 +7729,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4162,7 +7985,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4178,11 +8022,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4270,19 +8259,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4309,7 +8285,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4354,7 +8359,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4461,7 +8665,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4513,7 +8717,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4545,9 +8794,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4602,11 +8897,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4876,17 +9257,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4922,7 +9301,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5227,18 +9622,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5247,7 +9779,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5386,9 +10030,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblNeg using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,9 +10028,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblRem using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,15 +6737,124 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertToHelperArgumentType]
 INFO:  jitting method BringUpTest::DblRoots using LLILCJit
 Failed to read BringUpTest.DblRoots[sqrt]
 INFO:  jitting method String::Concat using LLILCJit
-Failed to read String.Concat[Tail call]
+Successfully read String.Concat
+
+define %System.String addrspace(1)* @String.Concat(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = icmp ne %System.Object addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = bitcast %System.String addrspace(1)* %3 to %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %4, %System.Object addrspace(1)** %arg0
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %7 = icmp ne %System.Object addrspace(1)* %6, null
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %10, %System.Object addrspace(1)** %arg1
+  br label %11
+
+; <label>:11                                      ; preds = %5, %8
+  %12 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  %13 = icmp ne %System.Object addrspace(1)* %12, null
+  br i1 %13, label %17, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %16, %System.Object addrspace(1)** %arg2
+  br label %17
+
+; <label>:17                                      ; preds = %11, %14
+  %18 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %19 = bitcast %System.Object addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 0
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %28 = call %System.String addrspace(1)* %27(%System.Object addrspace(1)* %18)
+  %29 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %30 = bitcast %System.Object addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
+  %32 = add i64 %31, 64
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = add i64 %34, 0
+  %36 = inttoptr i64 %35 to i64*
+  %37 = load i64, i64* %36
+  %38 = inttoptr i64 %37 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %39 = call %System.String addrspace(1)* %38(%System.Object addrspace(1)* %29)
+  %40 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  %41 = bitcast %System.Object addrspace(1)* %40 to i64 addrspace(1)*
+  %42 = load i64, i64 addrspace(1)* %41
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 0
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %50 = call %System.String addrspace(1)* %49(%System.Object addrspace(1)* %40)
+  %51 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %28, %System.String addrspace(1)* %39, %System.String addrspace(1)* %50)
+  ret %System.String addrspace(1)* %51
+}
+
 INFO:  jitting method Double::ToString using LLILCJit
-Failed to read Double.ToString[Tail call]
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %3)
+  ret %System.String addrspace(1)* %4
+}
+
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
 Failed to read NumberFormatInfo.get_CurrentInfo[convertHandle]
 INFO:  jitting method Object::Finalize using LLILCJit
@@ -3533,7 +6908,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -3565,7 +6985,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method CultureInfo::GetFormat using LLILCJit
 Failed to read CultureInfo.GetFormat[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
@@ -3837,17 +7305,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -3883,7 +7349,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -4299,7 +7781,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 104
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -4316,7 +7818,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -4514,11 +8052,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -4534,9 +8151,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -4630,7 +8277,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -4675,7 +8368,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -4722,11 +8527,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -4749,7 +8642,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4797,7 +8700,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4824,9 +8738,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4972,7 +8994,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4988,11 +9031,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -5080,19 +9268,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -5119,7 +9294,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -5164,7 +9368,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -5271,9 +9674,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5328,20 +9729,208 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Failed to read TextWriter.WriteLine[loadElem]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32, i32* %arg3
+  %17 = icmp sge i32 %16, 0
+  br i1 %17, label %23, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %20)
+  %22 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22, %System.String addrspace(1)* %19, %System.String addrspace(1)* %21)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22) #0
+  unreachable
+
+; <label>:23                                      ; preds = %15
+  %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %37, label %33
+
+; <label>:33                                      ; preds = %23
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
+  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+  unreachable
+
+; <label>:37                                      ; preds = %23
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
+  br label %89
+
+; <label>:39                                      ; preds = %89
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = icmp ne i32 %42, %45
+  br i1 %46, label %49, label %47
+
+; <label>:47                                      ; preds = %39
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
+  br label %49
+
+; <label>:49                                      ; preds = %39, %47
+  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
+  %52 = load i32, i32 addrspace(1)* %51, align 8
+  %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = sub i32 %52, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc0
+  %58 = load i32, i32* %arg3
+  %59 = icmp sle i32 %57, %58
+  br i1 %59, label %62, label %60
+
+; <label>:60                                      ; preds = %49
+  %61 = load i32, i32* %arg3
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %49, %60
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %64 = load i32, i32* %arg2
+  %65 = mul i32 %64, 2
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
+  %71 = load i32, i32 addrspace(1)* %70, align 8
+  %72 = mul i32 %71, 2
+  %73 = load i32, i32* %loc0
+  %74 = mul i32 %73, 2
+  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
+  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load i32, i32* %loc0
+  %81 = add i32 %79, %80
+  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  store i32 %81, i32 addrspace(1)* %82
+  %83 = load i32, i32* %arg2
+  %84 = load i32, i32* %loc0
+  %85 = add i32 %83, %84
+  store i32 %85, i32* %arg2
+  %86 = load i32, i32* %arg3
+  %87 = load i32, i32* %loc0
+  %88 = sub i32 %86, %87
+  store i32 %88, i32* %arg3
+  br label %89
+
+; <label>:89                                      ; preds = %37, %62
+  %90 = load i32, i32* %arg3
+  %91 = icmp sgt i32 %90, 0
+  br i1 %91, label %39, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
+  %95 = load i8, i8 addrspace(1)* %94, align 8
+  %96 = zext i8 %95 to i32
+  %97 = icmp eq i32 %96, 0
+  br i1 %97, label %100, label %98
+
+; <label>:98                                      ; preds = %92
+  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
+  br label %100
+
+; <label>:100                                     ; preds = %92, %98
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5350,7 +9939,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5489,5 +10190,62 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblSub using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblSubConst using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,9 +10028,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::DblVar using LLILCJit
@@ -3493,7 +6776,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3510,7 +6813,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3708,11 +7047,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3728,9 +7146,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3824,7 +7272,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3869,7 +7363,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3916,11 +7522,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3943,7 +7637,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3991,7 +7695,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4018,9 +7733,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4166,7 +7989,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4182,11 +8026,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4274,19 +8263,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4313,7 +8289,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4358,7 +8363,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4465,7 +8669,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4517,7 +8721,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4549,9 +8798,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4606,11 +8901,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4880,17 +9261,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4926,7 +9305,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5231,18 +9626,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5251,7 +9783,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5390,9 +10034,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPAdd using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPAddConst using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,9 +10028,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,15 +6737,86 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPArea using LLILCJit
-Failed to read BringUpTest.FPArea[Tail call]
+Successfully read BringUpTest.FPArea
+
+define float @BringUpTest.FPArea(float %param0, float %param1, float %param2) {
+entry:
+  %arg0 = alloca float
+  %arg1 = alloca float
+  %arg2 = alloca float
+  %loc0 = alloca float
+  store float %param0, float* %arg0
+  store float %param1, float* %arg1
+  store float %param2, float* %arg2
+  %0 = load float, float* %arg0
+  %1 = load float, float* %arg1
+  %2 = fadd float %0, %1
+  %3 = load float, float* %arg2
+  %4 = fadd float %2, %3
+  %5 = fdiv float %4, 2.000000e+00
+  store float %5, float* %loc0
+  %6 = load float, float* %loc0
+  %7 = load float, float* %loc0
+  %8 = load float, float* %arg0
+  %9 = fsub float %7, %8
+  %10 = fmul float %6, %9
+  %11 = load float, float* %loc0
+  %12 = load float, float* %arg1
+  %13 = fsub float %11, %12
+  %14 = fmul float %10, %13
+  %15 = load float, float* %loc0
+  %16 = load float, float* %arg2
+  %17 = fsub float %15, %16
+  %18 = fmul float %14, %17
+  %19 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (float)*)(float %18)
+  ret float %19
+}
+
 INFO:  jitting method BringUpTest::FPSqrt using LLILCJit
 Failed to read BringUpTest.FPSqrt[sqrt]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3496,7 +6833,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3694,11 +7067,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3714,9 +7166,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3810,7 +7292,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3855,7 +7383,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3902,11 +7542,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3929,7 +7657,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3977,7 +7715,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4004,9 +7753,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4152,7 +8009,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4168,11 +8046,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4260,19 +8283,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4299,7 +8309,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4344,7 +8383,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4451,7 +8689,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4503,7 +8741,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4535,9 +8818,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4592,11 +8921,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4866,17 +9281,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4912,7 +9325,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5217,18 +9646,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5237,7 +9803,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5376,9 +10054,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,13 +6737,50 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertHandle]
 INFO:  jitting method BringUpTest::FPArray using LLILCJit
 Failed to read BringUpTest.FPArray[loadElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3494,7 +6797,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3692,11 +7031,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3712,9 +7130,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3808,7 +7256,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3853,7 +7347,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3900,11 +7506,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3927,7 +7621,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3975,7 +7679,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4002,9 +7717,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4150,7 +7973,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4166,11 +8010,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4258,19 +8247,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4297,7 +8273,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4342,7 +8347,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4449,7 +8653,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4501,7 +8705,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4533,9 +8782,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4590,11 +8885,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4864,17 +9245,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4910,7 +9289,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5215,18 +9610,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5235,7 +9767,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5374,9 +10018,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPAvg2 using LLILCJit
@@ -3494,7 +6777,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3511,7 +6814,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3709,11 +7048,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3729,9 +7147,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3825,7 +7273,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3870,7 +7364,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3917,11 +7523,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3944,7 +7638,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3992,7 +7696,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4019,9 +7734,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4167,7 +7990,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4183,11 +8027,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4275,19 +8264,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4314,7 +8290,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4359,7 +8364,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4466,7 +8670,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4518,7 +8722,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4550,9 +8799,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4607,11 +8902,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4881,17 +9262,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4927,7 +9306,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5232,18 +9627,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5252,7 +9784,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5391,9 +10035,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPAvg6 using LLILCJit
@@ -3510,7 +6793,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3527,7 +6830,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3725,11 +7064,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3745,9 +7163,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3841,7 +7289,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3886,7 +7380,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3933,11 +7539,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3960,7 +7654,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4008,7 +7712,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4035,9 +7750,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4183,7 +8006,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4199,11 +8043,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4291,19 +8280,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4330,7 +8306,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4375,7 +8380,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4482,7 +8686,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4534,7 +8738,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4566,9 +8815,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4623,11 +8918,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4897,17 +9278,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4943,7 +9322,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5248,18 +9643,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5268,7 +9800,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5407,9 +10051,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPCall1 using LLILCJit
@@ -3507,7 +6790,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3524,7 +6827,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3722,11 +7061,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3742,9 +7160,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3838,7 +7286,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3883,7 +7377,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3930,11 +7536,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3957,7 +7651,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4005,7 +7709,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4032,9 +7747,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4180,7 +8003,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4196,11 +8040,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4288,19 +8277,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4327,7 +8303,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4372,7 +8377,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4479,7 +8683,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4531,7 +8735,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4563,9 +8812,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4620,11 +8915,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4894,17 +9275,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4940,7 +9319,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5245,18 +9640,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5265,7 +9797,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5404,9 +10048,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,11 +6737,49 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPCall2 using LLILCJit
-Failed to read BringUpTest.FPCall2[Tail call]
+Successfully read BringUpTest.FPCall2
+
+define float @BringUpTest.FPCall2(float %param0, float %param1, float %param2, float %param3) {
+entry:
+  %arg0 = alloca float
+  %arg1 = alloca float
+  %arg2 = alloca float
+  %arg3 = alloca float
+  store float %param0, float* %arg0
+  store float %param1, float* %arg1
+  store float %param2, float* %arg2
+  store float %param3, float* %arg3
+  %0 = load float, float* %arg0
+  %1 = load float, float* %arg1
+  %2 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (float, float)*)(float %0, float %1)
+  %3 = load float, float* %arg2
+  %4 = load float, float* %arg3
+  %5 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (float, float)*)(float %3, float %4)
+  %6 = call float inttoptr (i64 NORMALIZED_ADDRESS to float (float, float)*)(float %2, float %5)
+  ret float %6
+}
+
 INFO:  jitting method BringUpTest::FPAvg2 using LLILCJit
 Successfully read BringUpTest.FPAvg2
 
@@ -3496,7 +6800,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3513,7 +6837,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3711,11 +7071,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3731,9 +7170,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3827,7 +7296,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3872,7 +7387,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3919,11 +7546,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3946,7 +7661,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3994,7 +7719,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4021,9 +7757,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4169,7 +8013,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4185,11 +8050,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4277,19 +8287,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4316,7 +8313,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4361,7 +8387,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4468,7 +8693,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4520,7 +8745,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4552,9 +8822,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4609,11 +8925,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4883,17 +9285,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4929,7 +9329,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5234,18 +9650,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5254,7 +9807,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5393,9 +10058,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 
@@ -3538,7 +6821,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i64, i64* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3555,7 +6858,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3753,11 +7092,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3773,9 +7191,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3869,7 +7317,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3914,7 +7408,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3961,11 +7567,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3988,7 +7682,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4036,7 +7740,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4063,9 +7778,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4211,7 +8034,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4227,11 +8071,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4319,19 +8308,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4358,7 +8334,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4403,7 +8408,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4510,7 +8714,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4562,7 +8766,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4594,9 +8843,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4651,11 +8946,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i64, i64* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 16
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Int64::ToString using LLILCJit
+Successfully read Int64.ToString
+
+define %System.String addrspace(1)* @Int64.ToString(%System.Int64 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Int64 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Int64 addrspace(1)* %param0, %System.Int64 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
+  %1 = addrspacecast %System.Int64 addrspace(1)* %0 to i64*
+  %2 = load i64, i64* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4925,17 +9306,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4971,7 +9350,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5276,18 +9671,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5296,7 +9828,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5435,11 +10079,208 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 INFO:  jitting method BringUpTest::FPConvDbl2Lng using LLILCJit
 Successfully read BringUpTest.FPConvDbl2Lng
 
@@ -5453,7 +10294,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i64, i64* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  ret void
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5508,7 +10369,93 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i64, i64* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 24
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method UInt64::ToString using LLILCJit
+Successfully read UInt64.ToString
+
+define %System.String addrspace(1)* @UInt64.ToString(%System.UInt64 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.UInt64 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.UInt64 addrspace(1)* %param0, %System.UInt64 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.UInt64 addrspace(1)*, %System.UInt64 addrspace(1)** %this
+  %1 = addrspacecast %System.UInt64 addrspace(1)* %0 to i64*
+  %2 = load i64, i64* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPConvF2F using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,11 +10028,208 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 INFO:  jitting method BringUpTest::FPConvF2F using LLILCJit
 Successfully read BringUpTest.FPConvF2F
 
@@ -5402,7 +10243,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5457,7 +10318,93 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 
@@ -3542,7 +6825,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i32, i32* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 16
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3559,7 +6862,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3757,11 +7096,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3777,9 +7195,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3873,7 +7321,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3918,7 +7412,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3965,11 +7571,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3992,7 +7686,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4040,7 +7744,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4067,9 +7782,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4215,7 +8038,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4231,11 +8075,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4323,19 +8312,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4362,7 +8338,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4407,7 +8412,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4514,7 +8718,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4566,7 +8770,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4598,9 +8847,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4655,11 +8950,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i32, i32* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 0
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Int32::ToString using LLILCJit
+Successfully read Int32.ToString
+
+define %System.String addrspace(1)* @Int32.ToString(%System.Int32 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4929,17 +9310,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4975,7 +9354,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5280,18 +9675,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5300,7 +9832,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5439,11 +10083,208 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 INFO:  jitting method BringUpTest::FPConvF2I using LLILCJit
 Successfully read BringUpTest.FPConvF2I
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 
@@ -3538,7 +6821,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i64, i64* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3555,7 +6858,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3753,11 +7092,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3773,9 +7191,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3869,7 +7317,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3914,7 +7408,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3961,11 +7567,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3988,7 +7682,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4036,7 +7740,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4063,9 +7778,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4211,7 +8034,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4227,11 +8071,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4319,19 +8308,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4358,7 +8334,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4403,7 +8408,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4510,7 +8714,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4562,7 +8766,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4594,9 +8843,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4651,11 +8946,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i64, i64* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 16
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Int64::ToString using LLILCJit
+Successfully read Int64.ToString
+
+define %System.String addrspace(1)* @Int64.ToString(%System.Int64 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Int64 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Int64 addrspace(1)* %param0, %System.Int64 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
+  %1 = addrspacecast %System.Int64 addrspace(1)* %0 to i64*
+  %2 = load i64, i64* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4925,17 +9306,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4971,7 +9350,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5276,18 +9671,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5296,7 +9828,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5435,11 +10079,208 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 INFO:  jitting method BringUpTest::FPConvF2Lng using LLILCJit
 Successfully read BringUpTest.FPConvF2Lng
 
@@ -5453,7 +10294,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i64, i64* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  ret void
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5508,7 +10369,93 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i64, i64* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 24
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method UInt64::ToString using LLILCJit
+Successfully read UInt64.ToString
+
+define %System.String addrspace(1)* @UInt64.ToString(%System.UInt64 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.UInt64 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.UInt64 addrspace(1)* %param0, %System.UInt64 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.UInt64 addrspace(1)*, %System.UInt64 addrspace(1)** %this
+  %1 = addrspacecast %System.UInt64 addrspace(1)* %0 to i64*
+  %2 = load i64, i64* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPConvI2F using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,11 +10028,208 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 INFO:  jitting method BringUpTest::FPConvI2F using LLILCJit
 Successfully read BringUpTest.FPConvI2F
 
@@ -5402,7 +10243,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5457,9 +10318,95 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method BringUpTest::FPConvI2F using LLILCJit
 Successfully read BringUpTest.FPConvI2F
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,13 +6737,50 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPDist using LLILCJit
 Failed to read BringUpTest.FPDist[sqrt]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3494,7 +6797,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3692,11 +7031,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3712,9 +7130,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3808,7 +7256,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3853,7 +7347,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3900,11 +7506,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3927,7 +7621,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3975,7 +7679,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4002,9 +7717,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4150,7 +7973,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4166,11 +8010,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4258,19 +8247,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4297,7 +8273,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4342,7 +8347,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4449,7 +8653,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4501,7 +8705,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4533,9 +8782,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4590,11 +8885,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4864,17 +9245,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4910,7 +9289,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5215,18 +9610,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5235,7 +9767,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5374,9 +10018,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPDiv using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPDivConst using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,9 +10028,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPError using LLILCJit
@@ -3494,7 +6777,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3511,7 +6814,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3709,11 +7048,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3729,9 +7147,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3825,7 +7273,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3870,7 +7364,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3917,11 +7523,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3944,7 +7638,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3992,7 +7696,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4019,9 +7734,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4167,7 +7990,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4183,11 +8027,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4275,19 +8264,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4314,7 +8290,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4359,7 +8364,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4466,7 +8670,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4518,7 +8722,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4550,9 +8799,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4607,11 +8902,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4881,17 +9262,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4927,7 +9306,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5232,18 +9627,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5252,7 +9784,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5391,9 +10035,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPFillArray using LLILCJit
@@ -3479,7 +6762,27 @@ Failed to read BringUpTest.FPFillArray[storeElem]
 INFO:  jitting method BringUpTest::FPArray using LLILCJit
 Failed to read BringUpTest.FPArray[loadElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3496,7 +6799,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3694,11 +7033,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3714,9 +7132,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3810,7 +7258,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3855,7 +7349,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3902,11 +7508,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3929,7 +7623,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3977,7 +7681,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4004,9 +7719,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4152,7 +7975,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4168,11 +8012,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4260,19 +8249,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4299,7 +8275,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4344,7 +8349,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4451,7 +8655,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4503,7 +8707,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4535,9 +8784,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4592,11 +8887,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4866,17 +9247,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4912,7 +9291,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5217,18 +9612,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5237,7 +9769,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5376,9 +10020,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,15 +6737,52 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPMath using LLILCJit
 Failed to read BringUpTest.FPMath[Call intrinsic]
 INFO:  jitting method BringUpTest::FPMath using LLILCJit
-Failed to read BringUpTest.FPMath[Tail call]
+Failed to read BringUpTest.FPMath[Call intrinsic]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(double %param0) {
+entry:
+  %arg0 = alloca double
+  store double %param0, double* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load double, double* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 56
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3496,7 +6799,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3694,11 +7033,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3714,9 +7132,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3810,7 +7258,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3855,7 +7349,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3902,11 +7508,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3929,7 +7623,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3977,7 +7681,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4004,9 +7719,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4152,7 +7975,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4168,11 +8012,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4260,19 +8249,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4299,7 +8275,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4344,7 +8349,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4451,7 +8655,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4503,7 +8707,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4535,9 +8784,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4592,11 +8887,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load double, double* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 40
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, double)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, double %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, double %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca double
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store double %param1, double* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast double* %arg1 to double addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Double::ToString using LLILCJit
+Successfully read Double.ToString
+
+define %System.String addrspace(1)* @Double.ToString(%System.Double addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Double addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Double addrspace(1)* %param0, %System.Double addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Double addrspace(1)*, %System.Double addrspace(1)** %this
+  %1 = addrspacecast %System.Double addrspace(1)* %0 to double*
+  %2 = load double, double* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (double, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(double %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4866,17 +9247,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4912,7 +9291,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5217,18 +9612,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5237,7 +9769,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5376,9 +10020,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPMul using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPMulConst using LLILCJit
@@ -3489,7 +6772,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3506,7 +6809,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3704,11 +7043,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3724,9 +7142,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3820,7 +7268,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3865,7 +7359,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3912,11 +7518,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3939,7 +7633,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3987,7 +7691,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4014,9 +7729,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4162,7 +7985,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4178,11 +8022,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4270,19 +8259,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4309,7 +8285,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4354,7 +8359,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4461,7 +8665,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4513,7 +8717,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4545,9 +8794,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4602,11 +8897,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4876,17 +9257,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4922,7 +9301,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5227,18 +9622,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5247,7 +9779,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5386,9 +10030,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPNeg using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,9 +10028,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPRem using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,13 +6737,50 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertToHelperArgumentType]
 INFO:  jitting method BringUpTest::FPRoots using LLILCJit
 Failed to read BringUpTest.FPRoots[sqrt]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3494,7 +6797,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3692,11 +7031,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3712,9 +7130,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3808,7 +7256,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3853,7 +7347,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3900,11 +7506,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3927,7 +7621,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3975,7 +7679,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4002,9 +7717,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4150,7 +7973,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4166,11 +8010,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4258,19 +8247,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4297,7 +8273,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4342,7 +8347,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4449,7 +8653,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4501,7 +8705,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4533,9 +8782,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4590,11 +8885,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4864,17 +9245,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4910,7 +9289,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5215,18 +9610,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5235,7 +9767,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5374,15 +10018,304 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
-Failed to read String.Concat[Tail call]
+Successfully read String.Concat
+
+define %System.String addrspace(1)* @String.Concat(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = icmp ne %System.Object addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = bitcast %System.String addrspace(1)* %3 to %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %4, %System.Object addrspace(1)** %arg0
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %7 = icmp ne %System.Object addrspace(1)* %6, null
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %10, %System.Object addrspace(1)** %arg1
+  br label %11
+
+; <label>:11                                      ; preds = %5, %8
+  %12 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  %13 = icmp ne %System.Object addrspace(1)* %12, null
+  br i1 %13, label %17, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %16, %System.Object addrspace(1)** %arg2
+  br label %17
+
+; <label>:17                                      ; preds = %11, %14
+  %18 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %19 = bitcast %System.Object addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 0
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %28 = call %System.String addrspace(1)* %27(%System.Object addrspace(1)* %18)
+  %29 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %30 = bitcast %System.Object addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
+  %32 = add i64 %31, 64
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load i64, i64* %33
+  %35 = add i64 %34, 0
+  %36 = inttoptr i64 %35 to i64*
+  %37 = load i64, i64* %36
+  %38 = inttoptr i64 %37 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %39 = call %System.String addrspace(1)* %38(%System.Object addrspace(1)* %29)
+  %40 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  %41 = bitcast %System.Object addrspace(1)* %40 to i64 addrspace(1)*
+  %42 = load i64, i64 addrspace(1)* %41
+  %43 = add i64 %42, 64
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = add i64 %45, 0
+  %47 = inttoptr i64 %46 to i64*
+  %48 = load i64, i64* %47
+  %49 = inttoptr i64 %48 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %50 = call %System.String addrspace(1)* %49(%System.Object addrspace(1)* %40)
+  %51 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %28, %System.String addrspace(1)* %39, %System.String addrspace(1)* %50)
+  ret %System.String addrspace(1)* %51
+}
+
 INFO:  jitting method Single::ToString using LLILCJit
-Failed to read Single.ToString[Tail call]
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %3)
+  ret %System.String addrspace(1)* %4
+}
+
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
 Failed to read NumberFormatInfo.get_CurrentInfo[convertHandle]
 INFO:  jitting method String::ToString using LLILCJit
@@ -5497,7 +10430,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 104
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5552,7 +10505,174 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Failed to read TextWriter.WriteLine[loadElem]
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32, i32* %arg3
+  %17 = icmp sge i32 %16, 0
+  br i1 %17, label %23, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %20)
+  %22 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22, %System.String addrspace(1)* %19, %System.String addrspace(1)* %21)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22) #0
+  unreachable
+
+; <label>:23                                      ; preds = %15
+  %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %37, label %33
+
+; <label>:33                                      ; preds = %23
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
+  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+  unreachable
+
+; <label>:37                                      ; preds = %23
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
+  br label %89
+
+; <label>:39                                      ; preds = %89
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = icmp ne i32 %42, %45
+  br i1 %46, label %49, label %47
+
+; <label>:47                                      ; preds = %39
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
+  br label %49
+
+; <label>:49                                      ; preds = %39, %47
+  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
+  %52 = load i32, i32 addrspace(1)* %51, align 8
+  %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = sub i32 %52, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc0
+  %58 = load i32, i32* %arg3
+  %59 = icmp sle i32 %57, %58
+  br i1 %59, label %62, label %60
+
+; <label>:60                                      ; preds = %49
+  %61 = load i32, i32* %arg3
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %49, %60
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %64 = load i32, i32* %arg2
+  %65 = mul i32 %64, 2
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
+  %71 = load i32, i32 addrspace(1)* %70, align 8
+  %72 = mul i32 %71, 2
+  %73 = load i32, i32* %loc0
+  %74 = mul i32 %73, 2
+  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
+  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load i32, i32* %loc0
+  %81 = add i32 %79, %80
+  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  store i32 %81, i32 addrspace(1)* %82
+  %83 = load i32, i32* %arg2
+  %84 = load i32, i32* %loc0
+  %85 = add i32 %83, %84
+  store i32 %85, i32* %arg2
+  %86 = load i32, i32* %arg3
+  %87 = load i32, i32* %loc0
+  %88 = sub i32 %86, %87
+  store i32 %88, i32* %arg3
+  br label %89
+
+; <label>:89                                      ; preds = %37, %62
+  %90 = load i32, i32* %arg3
+  %91 = icmp sgt i32 %90, 0
+  br i1 %91, label %39, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
+  %95 = load i8, i8 addrspace(1)* %94, align 8
+  %96 = zext i8 %95 to i32
+  %97 = icmp eq i32 %96, 0
+  br i1 %97, label %100, label %98
+
+; <label>:98                                      ; preds = %92
+  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
+  br label %100
+
+; <label>:100                                     ; preds = %92, %98
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPSmall using LLILCJit
@@ -3505,7 +6788,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3522,7 +6825,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3720,11 +7059,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3740,9 +7158,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3836,7 +7284,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3881,7 +7375,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3928,11 +7534,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3955,7 +7649,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4003,7 +7707,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4030,9 +7745,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4178,7 +8001,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4194,11 +8038,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4286,19 +8275,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4325,7 +8301,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4370,7 +8375,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4477,7 +8681,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4529,7 +8733,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4561,9 +8810,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4618,11 +8913,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4892,17 +9273,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4938,7 +9317,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5243,18 +9638,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5263,7 +9795,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5402,9 +10046,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPSub using LLILCJit
@@ -3490,7 +6773,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3507,7 +6810,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3705,11 +7044,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3725,9 +7143,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3821,7 +7269,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3866,7 +7360,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3913,11 +7519,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3940,7 +7634,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3988,7 +7692,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4015,9 +7730,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4163,7 +7986,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4179,11 +8023,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4271,19 +8260,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4310,7 +8286,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4355,7 +8360,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4462,7 +8666,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4514,7 +8718,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4546,9 +8795,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4603,11 +8898,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4877,17 +9258,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4923,7 +9302,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5228,18 +9623,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5248,7 +9780,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5387,9 +10031,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPSubConst using LLILCJit
@@ -3487,7 +6770,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3504,7 +6807,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3702,11 +7041,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3722,9 +7140,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3818,7 +7266,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3863,7 +7357,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3910,11 +7516,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3937,7 +7631,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3985,7 +7689,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4012,9 +7727,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4160,7 +7983,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4176,11 +8020,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4268,19 +8257,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4307,7 +8283,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4352,7 +8357,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4459,7 +8663,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4511,7 +8715,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4543,9 +8792,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4600,11 +8895,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4874,17 +9255,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4920,7 +9299,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5225,18 +9620,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5245,7 +9777,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5384,9 +10028,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[abs]
 INFO:  jitting method BringUpTest::FPVar using LLILCJit
@@ -3493,7 +6776,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(float %param0) {
+entry:
+  %arg0 = alloca float
+  store float %param0, float* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load float, float* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 48
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3510,7 +6813,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3708,11 +7047,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3728,9 +7146,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3824,7 +7272,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3869,7 +7363,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3916,11 +7522,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3943,7 +7637,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3991,7 +7695,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4018,9 +7733,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4166,7 +7989,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4182,11 +8026,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4274,19 +8263,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4313,7 +8289,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4358,7 +8363,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4465,7 +8669,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4517,7 +8721,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4549,9 +8798,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4606,11 +8901,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load float, float* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, float)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, float %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, float %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca float
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store float %param1, float* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast float* %arg1 to float addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Single::ToString using LLILCJit
+Successfully read Single.ToString
+
+define %System.String addrspace(1)* @Single.ToString(%System.Single addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Single addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Single addrspace(1)* %param0, %System.Single addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Single addrspace(1)*, %System.Single addrspace(1)** %this
+  %1 = addrspacecast %System.Single addrspace(1)* %0 to float*
+  %2 = load float, float* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (float, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(float %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4880,17 +9261,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4926,7 +9305,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5231,18 +9626,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5251,7 +9783,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5390,9 +10034,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 
@@ -3524,7 +6807,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i32, i32* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 16
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3541,7 +6844,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3739,11 +7078,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3759,9 +7177,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3855,7 +7303,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3900,7 +7394,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3947,11 +7553,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3974,7 +7668,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4022,7 +7726,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4049,9 +7764,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4197,7 +8020,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4213,11 +8057,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4305,19 +8294,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4344,7 +8320,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4389,7 +8394,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4496,7 +8700,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4548,7 +8752,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4580,9 +8829,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4637,11 +8932,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i32, i32* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 0
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Int32::ToString using LLILCJit
+Successfully read Int32.ToString
+
+define %System.String addrspace(1)* @Int32.ToString(%System.Int32 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4911,17 +9292,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -4957,7 +9336,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5262,18 +9657,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5282,7 +9814,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5421,9 +10065,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertToHelperArgumentType]
 INFO:  jitting method BringUpTest::Gcd using LLILCJit
@@ -3526,7 +6809,7 @@ entry:
 INFO:  jitting method BringUpTest::print using LLILCJit
 Failed to read BringUpTest.print[storeElem]
 INFO:  jitting method String::Concat using LLILCJit
-Failed to read String.Concat[Tail call]
+Failed to read String.Concat[loadElem]
 INFO:  jitting method String::ToString using LLILCJit
 Successfully read String.ToString
 
@@ -3539,7 +6822,20 @@ entry:
 }
 
 INFO:  jitting method Int32::ToString using LLILCJit
-Failed to read Int32.ToString[Tail call]
+Successfully read Int32.ToString
+
+define %System.String addrspace(1)* @Int32.ToString(%System.Int32 addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %3)
+  ret %System.String addrspace(1)* %4
+}
+
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
 Failed to read NumberFormatInfo.get_CurrentInfo[convertHandle]
 INFO:  jitting method Object::Finalize using LLILCJit
@@ -3593,7 +6889,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -3625,7 +6966,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method CultureInfo::GetFormat using LLILCJit
 Failed to read CultureInfo.GetFormat[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
@@ -3897,17 +7286,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -3943,7 +7330,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -4250,7 +7653,27 @@ entry:
 INFO:  jitting method String::ConcatArray using LLILCJit
 Failed to read String.ConcatArray[loadElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 104
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -4267,7 +7690,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -4465,11 +7924,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -4485,9 +8023,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -4581,7 +8149,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -4626,7 +8240,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -4673,11 +8399,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -4700,7 +8514,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4748,7 +8572,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4775,9 +8610,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4923,7 +8866,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4939,11 +8903,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -5031,19 +9140,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -5070,7 +9166,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -5115,7 +9240,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -5222,9 +9546,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5279,20 +9601,208 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Failed to read TextWriter.WriteLine[loadElem]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32, i32* %arg3
+  %17 = icmp sge i32 %16, 0
+  br i1 %17, label %23, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %20)
+  %22 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22, %System.String addrspace(1)* %19, %System.String addrspace(1)* %21)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22) #0
+  unreachable
+
+; <label>:23                                      ; preds = %15
+  %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %37, label %33
+
+; <label>:33                                      ; preds = %23
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
+  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+  unreachable
+
+; <label>:37                                      ; preds = %23
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
+  br label %89
+
+; <label>:39                                      ; preds = %89
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = icmp ne i32 %42, %45
+  br i1 %46, label %49, label %47
+
+; <label>:47                                      ; preds = %39
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
+  br label %49
+
+; <label>:49                                      ; preds = %39, %47
+  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
+  %52 = load i32, i32 addrspace(1)* %51, align 8
+  %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = sub i32 %52, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc0
+  %58 = load i32, i32* %arg3
+  %59 = icmp sle i32 %57, %58
+  br i1 %59, label %62, label %60
+
+; <label>:60                                      ; preds = %49
+  %61 = load i32, i32* %arg3
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %49, %60
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %64 = load i32, i32* %arg2
+  %65 = mul i32 %64, 2
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
+  %71 = load i32, i32 addrspace(1)* %70, align 8
+  %72 = mul i32 %71, 2
+  %73 = load i32, i32* %loc0
+  %74 = mul i32 %73, 2
+  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
+  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load i32, i32* %loc0
+  %81 = add i32 %79, %80
+  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  store i32 %81, i32 addrspace(1)* %82
+  %83 = load i32, i32* %arg2
+  %84 = load i32, i32* %loc0
+  %85 = add i32 %83, %84
+  store i32 %85, i32* %arg2
+  %86 = load i32, i32* %arg3
+  %87 = load i32, i32* %loc0
+  %88 = sub i32 %86, %87
+  store i32 %88, i32* %arg3
+  br label %89
+
+; <label>:89                                      ; preds = %37, %62
+  %90 = load i32, i32* %arg3
+  %91 = icmp sgt i32 %90, 0
+  br i1 %91, label %39, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
+  %95 = load i8, i8 addrspace(1)* %94, align 8
+  %96 = zext i8 %95 to i32
+  %97 = icmp eq i32 %96, 0
+  br i1 %97, label %100, label %98
+
+; <label>:98                                      ; preds = %92
+  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
+  br label %100
+
+; <label>:100                                     ; preds = %92, %98
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5301,7 +9811,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5440,7 +10062,119 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
-Failed to read String.Concat[Tail call]
+Successfully read String.Concat
+
+define %System.String addrspace(1)* @String.Concat(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = icmp ne %System.Object addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = bitcast %System.String addrspace(1)* %3 to %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %4, %System.Object addrspace(1)** %arg0
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %7 = icmp ne %System.Object addrspace(1)* %6, null
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %10 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %10, %System.Object addrspace(1)** %arg1
+  br label %11
+
+; <label>:11                                      ; preds = %5, %8
+  %12 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %13 = bitcast %System.Object addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 0
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = inttoptr i64 %20 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %22 = call %System.String addrspace(1)* %21(%System.Object addrspace(1)* %12)
+  %23 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %24 = bitcast %System.Object addrspace(1)* %23 to i64 addrspace(1)*
+  %25 = load i64, i64 addrspace(1)* %24
+  %26 = add i64 %25, 64
+  %27 = inttoptr i64 %26 to i64*
+  %28 = load i64, i64* %27
+  %29 = add i64 %28, 0
+  %30 = inttoptr i64 %29 to i64*
+  %31 = load i64, i64* %30
+  %32 = inttoptr i64 %31 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %33 = call %System.String addrspace(1)* %32(%System.Object addrspace(1)* %23)
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %33)
+  ret %System.String addrspace(1)* %34
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertHandle]
 INFO:  jitting method MiscMethods::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertHandle]
 INFO:  jitting method BringUpTest::IntArraySum using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 
@@ -3573,7 +6856,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i64, i64* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 32
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3590,7 +6893,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3788,11 +7127,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3808,9 +7226,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3904,7 +7352,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3949,7 +7443,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3996,11 +7602,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -4023,7 +7717,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4071,7 +7775,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4098,9 +7813,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4246,7 +8069,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4262,11 +8106,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4354,19 +8343,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4393,7 +8369,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4438,7 +8443,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4545,7 +8749,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4597,7 +8801,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4629,9 +8878,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4686,11 +8981,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i64, i64* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 16
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i64)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i64 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i64
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i64 %param1, i64* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Int64::ToString using LLILCJit
+Successfully read Int64.ToString
+
+define %System.String addrspace(1)* @Int64.ToString(%System.Int64 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Int64 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Int64 addrspace(1)* %param0, %System.Int64 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Int64 addrspace(1)*, %System.Int64 addrspace(1)** %this
+  %1 = addrspacecast %System.Int64 addrspace(1)* %0 to i64*
+  %2 = load i64, i64* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i64, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i64 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -4960,17 +9341,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -5006,7 +9385,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5311,18 +9706,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5331,7 +9863,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5470,11 +10114,208 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 INFO:  jitting method BringUpTest::IntConv using LLILCJit
 Successfully read BringUpTest.IntConv
 
@@ -5500,7 +10341,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i32, i32* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 16
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  ret void
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5555,9 +10416,95 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i32, i32* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 0
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Int32::ToString using LLILCJit
+Successfully read Int32.ToString
+
+define %System.String addrspace(1)* @Int32.ToString(%System.Int32 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method BringUpTest::IntConv using LLILCJit
 Successfully read BringUpTest.IntConv
 
@@ -5598,7 +10545,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i32, i32* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 24
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  ret void
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5653,7 +10620,93 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i32, i32* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method UInt32::ToString using LLILCJit
+Successfully read UInt32.ToString
+
+define %System.String addrspace(1)* @UInt32.ToString(%System.UInt32 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.UInt32 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.UInt32 addrspace(1)* %param0, %System.UInt32 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.UInt32 addrspace(1)*, %System.UInt32 addrspace(1)** %this
+  %1 = addrspacecast %System.UInt32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 
@@ -3642,7 +6925,27 @@ entry:
 INFO:  jitting method IntPtr::op_Explicit using LLILCJit
 Failed to read IntPtr.op_Explicit[Convert Overflow]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i32, i32* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 24
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3659,7 +6962,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3857,11 +7196,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3877,9 +7295,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3973,7 +7421,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -4018,7 +7512,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -4065,11 +7671,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -4092,7 +7786,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4140,7 +7844,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4167,9 +7882,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4315,7 +8138,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4331,11 +8175,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4423,19 +8412,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4462,7 +8438,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4507,7 +8512,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4614,7 +8818,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4666,7 +8870,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4698,9 +8947,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4755,11 +9050,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i32, i32* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method UInt32::ToString using LLILCJit
+Successfully read UInt32.ToString
+
+define %System.String addrspace(1)* @UInt32.ToString(%System.UInt32 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.UInt32 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.UInt32 addrspace(1)* %param0, %System.UInt32 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.UInt32 addrspace(1)*, %System.UInt32 addrspace(1)** %this
+  %1 = addrspacecast %System.UInt32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -5029,17 +9410,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -5075,7 +9454,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5380,18 +9775,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5400,7 +9932,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5539,11 +10183,208 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 INFO:  jitting method BringUpTest::LngConv using LLILCJit
 Successfully read BringUpTest.LngConv
 
@@ -5564,7 +10405,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i32, i32* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 16
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  ret void
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5619,9 +10480,95 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i32, i32* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 0
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Int32::ToString using LLILCJit
+Successfully read Int32.ToString
+
+define %System.String addrspace(1)* @Int32.ToString(%System.Int32 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method BringUpTest::LngConv using LLILCJit
 Successfully read BringUpTest.LngConv
 
@@ -5657,8 +10604,8 @@ entry:
   %3 = sext i16 %2 to i32
   %4 = trunc i32 %3 to i16
   store i16 %4, i16* %loc0
-  %5 = addrspacecast i16 addrspace(1)* %0 to i32*
-  store i32 %3, i32* %5, align 8
+  %5 = trunc i32 %3 to i16
+  store i16 %5, i16 addrspace(1)* %0, align 8
   %6 = load i16, i16* %loc0
   %7 = sext i16 %6 to i32
   %8 = trunc i32 %7 to i16
@@ -5681,8 +10628,8 @@ entry:
   %3 = zext i16 %2 to i32
   %4 = trunc i32 %3 to i16
   store i16 %4, i16* %loc0
-  %5 = addrspacecast i16 addrspace(1)* %0 to i32*
-  store i32 %3, i32* %5, align 8
+  %5 = trunc i32 %3 to i16
+  store i16 %5, i16 addrspace(1)* %0, align 8
   %6 = load i16, i16* %loc0
   %7 = zext i16 %6 to i32
   %8 = trunc i32 %7 to i16
@@ -5705,8 +10652,8 @@ entry:
   %3 = sext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   store i8 %4, i8* %loc0
-  %5 = addrspacecast i8 addrspace(1)* %0 to i32*
-  store i32 %3, i32* %5, align 8
+  %5 = trunc i32 %3 to i8
+  store i8 %5, i8 addrspace(1)* %0, align 8
   %6 = load i8, i8* %loc0
   %7 = sext i8 %6 to i32
   %8 = trunc i32 %7 to i8
@@ -5729,8 +10676,8 @@ entry:
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   store i8 %4, i8* %loc0
-  %5 = addrspacecast i8 addrspace(1)* %0 to i32*
-  store i32 %3, i32* %5, align 8
+  %5 = trunc i32 %3 to i8
+  store i8 %5, i8 addrspace(1)* %0, align 8
   %6 = load i8, i8* %loc0
   %7 = zext i8 %6 to i32
   %8 = trunc i32 %7 to i8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,9 +6737,33 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
-Failed to read BringUpTest.Main[Tail call]
+Successfully read BringUpTest.Main
+
+define i32 @BringUpTest.Main() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
 INFO:  jitting method BringUpTest::OpMembersOfStructLocal using LLILCJit
 Successfully read BringUpTest.OpMembersOfStructLocal
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 
@@ -4064,7 +7347,27 @@ entry:
 }
 
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load i32, i32* %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 96
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 16
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -4081,7 +7384,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -4279,11 +7618,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -4299,9 +7717,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -4395,7 +7843,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -4440,7 +7934,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -4487,11 +8093,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -4514,7 +8208,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4562,7 +8266,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4589,9 +8304,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4737,7 +8560,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4753,11 +8597,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4845,19 +8834,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4884,7 +8860,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4929,7 +8934,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -5036,7 +9240,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -5088,7 +9292,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -5120,9 +9369,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5177,11 +9472,97 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load i32, i32* %arg1
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 80
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 0
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, i32)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
+  %11 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %12 = bitcast %System.IO.TextWriter addrspace(1)* %11 to i64 addrspace(1)*
+  %13 = load i64, i64 addrspace(1)* %12
+  %14 = add i64 %13, 88
+  %15 = inttoptr i64 %14 to i64*
+  %16 = load i64, i64* %15
+  %17 = add i64 %16, 40
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*)*
+  call void %20(%System.IO.TextWriter addrspace(1)* %11)
+  ret void
+}
+
 INFO:  jitting method TextWriter::Write using LLILCJit
-Failed to read TextWriter.Write[Tail call]
+Successfully read TextWriter.Write
+
+define void @TextWriter.Write(%System.IO.TextWriter addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  %arg1 = alloca i32
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
+  %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 32
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
+  %12 = call %System.IFormatProvider addrspace(1)* %11(%System.IO.TextWriter addrspace(1)* %2)
+  %13 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
+  %14 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %13, %System.IFormatProvider addrspace(1)* %12)
+  %15 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 80
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 56
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %23(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %14)
+  ret void
+}
+
+INFO:  jitting method Int32::ToString using LLILCJit
+Successfully read Int32.ToString
+
+define %System.String addrspace(1)* @Int32.ToString(%System.Int32 addrspace(1)* %param0, %System.IFormatProvider addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  %arg1 = alloca %System.IFormatProvider addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  store %System.IFormatProvider addrspace(1)* %param1, %System.IFormatProvider addrspace(1)** %arg1
+  %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = load %System.IFormatProvider addrspace(1)*, %System.IFormatProvider addrspace(1)** %arg1
+  %4 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* (%System.IFormatProvider addrspace(1)*)*)(%System.IFormatProvider addrspace(1)* %3)
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method NumberFormatInfo::GetInstance using LLILCJit
-Failed to read NumberFormatInfo.GetInstance[Tail call]
+Failed to read NumberFormatInfo.GetInstance[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
 Successfully read CultureInfo.get_NumberFormat
 
@@ -5451,17 +9832,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -5497,7 +9876,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -5802,18 +10197,155 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %64, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %3)
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %5 = getelementptr inbounds %System.String, %System.String addrspace(1)* %4, i32 0, i32 1
+  %6 = load i32, i32 addrspace(1)* %5
+  store i32 %6, i32* %loc0
+  store i32 0, i32* %loc1
+  br label %53
+
+; <label>:7                                       ; preds = %53
+  %8 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %8, i32 0, i32 9
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 10
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = icmp ne i32 %10, %13
+  br i1 %14, label %17, label %15
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %16, i8 0, i8 0)
+  br label %17
+
+; <label>:17                                      ; preds = %7, %15
+  %18 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %19 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %18, i32 0, i32 10
+  %20 = load i32, i32 addrspace(1)* %19, align 8
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 9
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = sub i32 %20, %23
+  store i32 %24, i32* %loc2
+  %25 = load i32, i32* %loc2
+  %26 = load i32, i32* %loc0
+  %27 = icmp sle i32 %25, %26
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %17
+  %29 = load i32, i32* %loc0
+  store i32 %29, i32* %loc2
+  br label %30
+
+; <label>:30                                      ; preds = %17, %28
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load i32, i32* %loc1
+  %33 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %34 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %33, i32 0, i32 7
+  %35 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %34, align 8
+  %36 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %37 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 9
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = load i32, i32* %loc2
+  %NullCheck = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %31, i32 %32, %"System.Char[]" addrspace(1)* %35, i32 %38, i32 %39)
+  %41 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %42 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  %43 = load i32, i32 addrspace(1)* %42, align 8
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %41, i32 0, i32 9
+  store i32 %45, i32 addrspace(1)* %46
+  %47 = load i32, i32* %loc1
+  %48 = load i32, i32* %loc2
+  %49 = add i32 %47, %48
+  store i32 %49, i32* %loc1
+  %50 = load i32, i32* %loc0
+  %51 = load i32, i32* %loc2
+  %52 = sub i32 %50, %51
+  store i32 %52, i32* %loc0
+  br label %53
+
+; <label>:53                                      ; preds = %2, %40
+  %54 = load i32, i32* %loc0
+  %55 = icmp sgt i32 %54, 0
+  br i1 %55, label %7, label %56
+
+; <label>:56                                      ; preds = %53
+  %57 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %58 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %57, i32 0, i32 11
+  %59 = load i8, i8 addrspace(1)* %58, align 8
+  %60 = zext i8 %59 to i32
+  %61 = icmp eq i32 %60, 0
+  br i1 %61, label %64, label %62
+
+; <label>:62                                      ; preds = %56
+  %63 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %63, i8 1, i8 0)
+  br label %64
+
+; <label>:64                                      ; preds = %entry, %56, %62
+  ret void
+
+ThrowNullRef:                                     ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5822,7 +10354,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5961,9 +10605,206 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Successfully read TextWriter.WriteLine
+
+define void @TextWriter.WriteLine(%System.IO.TextWriter addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.TextWriter addrspace(1)*
+  store %System.IO.TextWriter addrspace(1)* %param0, %System.IO.TextWriter addrspace(1)** %this
+  %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %1 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
+  %2 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
+  %3 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %2, align 8
+  %4 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 72
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 40
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
+  call void %12(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %3)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret void
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %4)
+  store i32 0, i32* %loc0
+  %5 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %6 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = zext i32 %7 to i64
+  %9 = trunc i64 %8 to i32
+  store i32 %9, i32* %loc1
+  br label %60
+
+; <label>:10                                      ; preds = %60
+  %11 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %12 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %11, i32 0, i32 9
+  %13 = load i32, i32 addrspace(1)* %12, align 8
+  %14 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %15 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %14, i32 0, i32 10
+  %16 = load i32, i32 addrspace(1)* %15, align 8
+  %17 = icmp ne i32 %13, %16
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %10
+  %19 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %19, i8 0, i8 0)
+  br label %20
+
+; <label>:20                                      ; preds = %10, %18
+  %21 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %22 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %21, i32 0, i32 10
+  %23 = load i32, i32 addrspace(1)* %22, align 8
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 9
+  %26 = load i32, i32 addrspace(1)* %25, align 8
+  %27 = sub i32 %23, %26
+  store i32 %27, i32* %loc2
+  %28 = load i32, i32* %loc2
+  %29 = load i32, i32* %loc1
+  %30 = icmp sle i32 %28, %29
+  br i1 %30, label %33, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load i32, i32* %loc1
+  store i32 %32, i32* %loc2
+  br label %33
+
+; <label>:33                                      ; preds = %20, %31
+  %34 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %35 = load i32, i32* %loc0
+  %36 = mul i32 %35, 2
+  %37 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 7
+  %39 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = mul i32 %42, 2
+  %44 = load i32, i32* %loc2
+  %45 = mul i32 %44, 2
+  %46 = bitcast %"System.Char[]" addrspace(1)* %34 to %System.Array addrspace(1)*
+  %47 = bitcast %"System.Char[]" addrspace(1)* %39 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %46, i32 %36, %System.Array addrspace(1)* %47, i32 %43, i32 %45)
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %49 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  %50 = load i32, i32 addrspace(1)* %49, align 8
+  %51 = load i32, i32* %loc2
+  %52 = add i32 %50, %51
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %48, i32 0, i32 9
+  store i32 %52, i32 addrspace(1)* %53
+  %54 = load i32, i32* %loc0
+  %55 = load i32, i32* %loc2
+  %56 = add i32 %54, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc1
+  %58 = load i32, i32* %loc2
+  %59 = sub i32 %57, %58
+  store i32 %59, i32* %loc1
+  br label %60
+
+; <label>:60                                      ; preds = %3, %33
+  %61 = load i32, i32* %loc1
+  %62 = icmp sgt i32 %61, 0
+  br i1 %62, label %10, label %63
+
+; <label>:63                                      ; preds = %60
+  %64 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %65 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %64, i32 0, i32 11
+  %66 = load i8, i8 addrspace(1)* %65, align 8
+  %67 = zext i8 %66 to i32
+  %68 = icmp eq i32 %67, 0
+  br i1 %68, label %71, label %69
+
+; <label>:69                                      ; preds = %63
+  %70 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %70, i8 1, i8 0)
+  br label %71
+
+; <label>:71                                      ; preds = %63, %69
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[AddressOfValue]
 INFO:  jitting method BringUpTest::StructFldAddr using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[AddressOfValue]
 INFO:  jitting method Point::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,11 +6737,28 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[storeElem]
 INFO:  jitting method String::Concat using LLILCJit
-Failed to read String.Concat[Tail call]
+Failed to read String.Concat[loadElem]
 INFO:  jitting method String::ToString using LLILCJit
 Successfully read String.ToString
 
@@ -3488,7 +6771,20 @@ entry:
 }
 
 INFO:  jitting method Int32::ToString using LLILCJit
-Failed to read Int32.ToString[Tail call]
+Successfully read Int32.ToString
+
+define %System.String addrspace(1)* @Int32.ToString(%System.Int32 addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Int32 addrspace(1)*
+  store %System.Int32 addrspace(1)* %param0, %System.Int32 addrspace(1)** %this
+  %0 = load %System.Int32 addrspace(1)*, %System.Int32 addrspace(1)** %this
+  %1 = addrspacecast %System.Int32 addrspace(1)* %0 to i32*
+  %2 = load i32, i32* %1, align 8
+  %3 = call %System.Globalization.NumberFormatInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.NumberFormatInfo addrspace(1)* ()*)()
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32, %System.String addrspace(1)*, %System.Globalization.NumberFormatInfo addrspace(1)*)*)(i32 %2, %System.String addrspace(1)* null, %System.Globalization.NumberFormatInfo addrspace(1)* %3)
+  ret %System.String addrspace(1)* %4
+}
+
 INFO:  jitting method NumberFormatInfo::get_CurrentInfo using LLILCJit
 Failed to read NumberFormatInfo.get_CurrentInfo[convertHandle]
 INFO:  jitting method Object::Finalize using LLILCJit
@@ -3542,7 +6838,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -3574,7 +6915,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method CultureInfo::GetFormat using LLILCJit
 Failed to read CultureInfo.GetFormat[convertHandle]
 INFO:  jitting method CultureInfo::get_NumberFormat using LLILCJit
@@ -3846,17 +7235,15 @@ entry:
 }
 
 INFO:  jitting method CultureData::get_IsInvariantCulture using LLILCJit
-Failed to read CultureData.get_IsInvariantCulture[Tail call]
-INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
-Successfully read CultureData.get_UseUserOverride
+Successfully read CultureData.get_IsInvariantCulture
 
-define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+define i8 @CultureData.get_IsInvariantCulture(%System.Globalization.CultureData addrspace(1)* %param0) {
 entry:
   %this = alloca %System.Globalization.CultureData addrspace(1)*
   store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
   %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
-  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %1 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %0)
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %1)
   %3 = zext i8 %2 to i32
   %4 = trunc i32 %3 to i8
   ret i8 %4
@@ -3892,7 +7279,23 @@ entry:
 }
 
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
-Failed to read CultureData.DoGetLocaleInfo[Tail call]
+Successfully read CultureData.DoGetLocaleInfo
+
+define %System.String addrspace(1)* @CultureData.DoGetLocaleInfo(%System.Globalization.CultureData addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %2 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %1, i32 0, i32 2
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %2, align 8
+  %4 = load i32, i32* %arg1
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Globalization.CultureData addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.Globalization.CultureData addrspace(1)* %0, %System.String addrspace(1)* %3, i32 %4)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method CultureData::DoGetLocaleInfo using LLILCJit
 Successfully read CultureData.DoGetLocaleInfo
 
@@ -4199,7 +7602,27 @@ entry:
 INFO:  jitting method String::ConcatArray using LLILCJit
 Failed to read String.ConcatArray[loadElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 104
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -4216,7 +7639,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -4414,11 +7873,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -4434,9 +7972,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -4530,7 +8098,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -4575,7 +8189,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -4622,11 +8348,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -4649,7 +8463,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -4697,7 +8521,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4724,9 +8559,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4872,7 +8815,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4888,11 +8852,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4980,19 +9089,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -5019,7 +9115,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -5064,7 +9189,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -5171,9 +9495,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -5228,20 +9550,208 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Failed to read TextWriter.WriteLine[loadElem]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32, i32* %arg3
+  %17 = icmp sge i32 %16, 0
+  br i1 %17, label %23, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %20)
+  %22 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22, %System.String addrspace(1)* %19, %System.String addrspace(1)* %21)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22) #0
+  unreachable
+
+; <label>:23                                      ; preds = %15
+  %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %37, label %33
+
+; <label>:33                                      ; preds = %23
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
+  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+  unreachable
+
+; <label>:37                                      ; preds = %23
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
+  br label %89
+
+; <label>:39                                      ; preds = %89
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = icmp ne i32 %42, %45
+  br i1 %46, label %49, label %47
+
+; <label>:47                                      ; preds = %39
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
+  br label %49
+
+; <label>:49                                      ; preds = %39, %47
+  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
+  %52 = load i32, i32 addrspace(1)* %51, align 8
+  %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = sub i32 %52, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc0
+  %58 = load i32, i32* %arg3
+  %59 = icmp sle i32 %57, %58
+  br i1 %59, label %62, label %60
+
+; <label>:60                                      ; preds = %49
+  %61 = load i32, i32* %arg3
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %49, %60
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %64 = load i32, i32* %arg2
+  %65 = mul i32 %64, 2
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
+  %71 = load i32, i32 addrspace(1)* %70, align 8
+  %72 = mul i32 %71, 2
+  %73 = load i32, i32* %loc0
+  %74 = mul i32 %73, 2
+  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
+  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load i32, i32* %loc0
+  %81 = add i32 %79, %80
+  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  store i32 %81, i32 addrspace(1)* %82
+  %83 = load i32, i32* %arg2
+  %84 = load i32, i32* %loc0
+  %85 = add i32 %83, %84
+  store i32 %85, i32* %arg2
+  %86 = load i32, i32* %arg3
+  %87 = load i32, i32* %loc0
+  %88 = sub i32 %86, %87
+  store i32 %88, i32* %arg3
+  br label %89
+
+; <label>:89                                      ; preds = %37, %62
+  %90 = load i32, i32* %arg3
+  %91 = icmp sgt i32 %90, 0
+  br i1 %91, label %39, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
+  %95 = load i8, i8 addrspace(1)* %94, align 8
+  %96 = zext i8 %95 to i32
+  %97 = icmp eq i32 %96, 0
+  br i1 %97, label %100, label %98
+
+; <label>:98                                      ; preds = %92
+  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
+  br label %100
+
+; <label>:100                                     ; preds = %92, %98
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -5250,7 +9760,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -5389,7 +10011,64 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Swap using LLILCJit
 Successfully read BringUpTest.Swap
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method SwitchTest::Main using LLILCJit
 Successfully read SwitchTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[convertToHelperArgumentType]
 INFO:  jitting method BringUpTest::Unbox using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Successfully read BringUpTest.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,7 +6737,24 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method child::Main using LLILCJit
 Successfully read child.Main
 

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,11 +6737,48 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method Complex_Array_Test::Main using LLILCJit
 Failed to read Complex_Array_Test.Main[loadElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 104
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3492,7 +6795,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3690,11 +7029,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3710,9 +7128,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3806,7 +7254,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3851,7 +7345,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3898,11 +7504,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3925,7 +7619,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3973,7 +7677,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4000,9 +7715,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4148,7 +7971,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4164,11 +8008,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4256,19 +8245,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4295,7 +8271,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4340,7 +8345,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4447,7 +8651,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4499,7 +8703,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4531,9 +8780,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4588,20 +8883,208 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Failed to read TextWriter.WriteLine[loadElem]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32, i32* %arg3
+  %17 = icmp sge i32 %16, 0
+  br i1 %17, label %23, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %20)
+  %22 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22, %System.String addrspace(1)* %19, %System.String addrspace(1)* %21)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22) #0
+  unreachable
+
+; <label>:23                                      ; preds = %15
+  %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %37, label %33
+
+; <label>:33                                      ; preds = %23
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
+  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+  unreachable
+
+; <label>:37                                      ; preds = %23
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
+  br label %89
+
+; <label>:39                                      ; preds = %89
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = icmp ne i32 %42, %45
+  br i1 %46, label %49, label %47
+
+; <label>:47                                      ; preds = %39
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
+  br label %49
+
+; <label>:49                                      ; preds = %39, %47
+  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
+  %52 = load i32, i32 addrspace(1)* %51, align 8
+  %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = sub i32 %52, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc0
+  %58 = load i32, i32* %arg3
+  %59 = icmp sle i32 %57, %58
+  br i1 %59, label %62, label %60
+
+; <label>:60                                      ; preds = %49
+  %61 = load i32, i32* %arg3
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %49, %60
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %64 = load i32, i32* %arg2
+  %65 = mul i32 %64, 2
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
+  %71 = load i32, i32 addrspace(1)* %70, align 8
+  %72 = mul i32 %71, 2
+  %73 = load i32, i32* %loc0
+  %74 = mul i32 %73, 2
+  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
+  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load i32, i32* %loc0
+  %81 = add i32 %79, %80
+  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  store i32 %81, i32 addrspace(1)* %82
+  %83 = load i32, i32* %arg2
+  %84 = load i32, i32* %loc0
+  %85 = add i32 %83, %84
+  store i32 %85, i32* %arg2
+  %86 = load i32, i32* %arg3
+  %87 = load i32, i32* %loc0
+  %88 = sub i32 %86, %87
+  store i32 %88, i32* %arg3
+  br label %89
+
+; <label>:89                                      ; preds = %37, %62
+  %90 = load i32, i32* %arg3
+  %91 = icmp sgt i32 %90, 0
+  br i1 %91, label %39, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
+  %95 = load i8, i8 addrspace(1)* %94, align 8
+  %96 = zext i8 %95 to i32
+  %97 = icmp eq i32 %96, 0
+  br i1 %97, label %100, label %98
+
+; <label>:98                                      ; preds = %92
+  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
+  br label %100
+
+; <label>:100                                     ; preds = %92, %98
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -4610,7 +9093,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -4749,5 +9344,62 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -73,7 +73,31 @@ ThrowNullRef:                                     ; preds = %7
 }
 
 INFO:  jitting method Monitor::Enter using LLILCJit
-Failed to read Monitor.Enter[Tail call]
+Successfully read Monitor.Enter
+
+define void @Monitor.Enter(%System.Object addrspace(1)* %param0, i8 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca i8 addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store i8 addrspace(1)* %param1, i8 addrspace(1)** %arg1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  %1 = load i8, i8 addrspace(1)* %0, align 8
+  %2 = sext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %6, i8 addrspace(1)* %7)
+  ret void
+}
+
 INFO:  jitting method AppDomainSetup::.ctor using LLILCJit
 Successfully read AppDomainSetup..ctor
 
@@ -223,7 +247,21 @@ ThrowNullRef9:                                    ; preds = %25
 }
 
 INFO:  jitting method AppDomainSetup::get_ApplicationBase using LLILCJit
-Failed to read AppDomainSetup.get_ApplicationBase[Tail call]
+Successfully read AppDomainSetup.get_ApplicationBase
+
+define %System.String addrspace(1)* @AppDomainSetup.get_ApplicationBase(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %2 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %1)
+  %3 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %0, %System.String addrspace(1)* %2, i8 0)
+  ret %System.String addrspace(1)* %3
+}
+
+INFO:  jitting method AppDomainSetup::GetUnsecureApplicationBase using LLILCJit
+Failed to read AppDomainSetup.GetUnsecureApplicationBase[loadElem]
 INFO:  jitting method AppDomainSetup::VerifyDir using LLILCJit
 Successfully read AppDomainSetup.VerifyDir
 
@@ -271,9 +309,135 @@ entry:
 INFO:  jitting method AppDomainSetup::SetupDefaults using LLILCJit
 Failed to read AppDomainSetup.SetupDefaults[storeElem]
 INFO:  jitting method String::LastIndexOfAny using LLILCJit
-Failed to read String.LastIndexOfAny[Tail call]
+Successfully read String.LastIndexOfAny
+
+define i32 @String.LastIndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = sub i32 %4, 1
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 %5, i32 %8)
+  ret i32 %9
+}
+
 INFO:  jitting method String::Substring using LLILCJit
-Failed to read String.Substring[Tail call]
+Successfully read String.Substring
+
+define %System.String addrspace(1)* @String.Substring(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg1
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg1
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = getelementptr inbounds %System.String, %System.String addrspace(1)* %9, i32 0, i32 1
+  %11 = load i32, i32 addrspace(1)* %10
+  %12 = icmp sle i32 %8, %11
+  br i1 %12, label %18, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %16 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %15)
+  %17 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17, %System.String addrspace(1)* %14, %System.String addrspace(1)* %16)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %17) #0
+  unreachable
+
+; <label>:18                                      ; preds = %7
+  %19 = load i32, i32* %arg2
+  %20 = icmp sge i32 %19, 0
+  br i1 %20, label %26, label %21
+
+; <label>:21                                      ; preds = %18
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %23)
+  %25 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25, %System.String addrspace(1)* %22, %System.String addrspace(1)* %24)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %25) #0
+  unreachable
+
+; <label>:26                                      ; preds = %18
+  %27 = load i32, i32* %arg1
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %29 = getelementptr inbounds %System.String, %System.String addrspace(1)* %28, i32 0, i32 1
+  %30 = load i32, i32 addrspace(1)* %29
+  %31 = load i32, i32* %arg2
+  %32 = sub i32 %30, %31
+  %33 = icmp sle i32 %27, %32
+  br i1 %33, label %39, label %34
+
+; <label>:34                                      ; preds = %26
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %37 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %36)
+  %38 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38, %System.String addrspace(1)* %35, %System.String addrspace(1)* %37)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %38) #0
+  unreachable
+
+; <label>:39                                      ; preds = %26
+  %40 = load i32, i32* %arg2
+  %41 = icmp ne i32 %40, 0
+  br i1 %41, label %44, label %42
+
+; <label>:42                                      ; preds = %39
+  %43 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %43
+
+; <label>:44                                      ; preds = %39
+  %45 = load i32, i32* %arg1
+  %46 = icmp ne i32 %45, 0
+  br i1 %46, label %55, label %47
+
+; <label>:47                                      ; preds = %44
+  %48 = load i32, i32* %arg2
+  %49 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %50 = getelementptr inbounds %System.String, %System.String addrspace(1)* %49, i32 0, i32 1
+  %51 = load i32, i32 addrspace(1)* %50
+  %52 = icmp ne i32 %48, %51
+  br i1 %52, label %55, label %53
+
+; <label>:53                                      ; preds = %47
+  %54 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %54
+
+; <label>:55                                      ; preds = %44, %47
+  %56 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %57 = load i32, i32* %arg1
+  %58 = load i32, i32* %arg2
+  %59 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %56, i32 %57, i32 %58)
+  ret %System.String addrspace(1)* %59
+}
+
 INFO:  jitting method String::InternalSubString using LLILCJit
 Successfully read String.InternalSubString
 
@@ -334,9 +498,626 @@ ThrowNullRef1:                                    ; preds = %3
 }
 
 INFO:  jitting method String::wstrcpy using LLILCJit
-Failed to read String.wstrcpy[Tail call]
+Successfully read String.wstrcpy
+
+define void @String.wstrcpy(i16* %param0, i16* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i16*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  store i16* %param0, i16** %arg0
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i16*, i16** %arg0
+  %1 = load i16*, i16** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = mul i32 %2, 2
+  %4 = bitcast i16* %0 to i8*
+  %5 = bitcast i16* %1 to i8*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i32)*)(i8* %4, i8* %5, i32 %3)
+  ret void
+}
+
+INFO:  jitting method Buffer::Memcpy using LLILCJit
+Successfully read Buffer.Memcpy
+
+define void @Buffer.Memcpy(i8* %param0, i8* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i32
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i32, i32* %arg2
+  %3 = zext i32 %2 to i64
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %3)
+  ret void
+}
+
 INFO:  jitting method Buffer::Memmove using LLILCJit
-Failed to read Buffer.Memmove[Tail call]
+Successfully read Buffer.Memmove
+
+define void @Buffer.Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  %loc0 = alloca i64
+  %loc1 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = ptrtoint i8* %0 to i64
+  %2 = load i8*, i8** %arg1
+  %3 = ptrtoint i8* %2 to i64
+  %4 = sub i64 %1, %3
+  %5 = load i64, i64* %arg2
+  %6 = icmp ult i64 %4, %5
+  br i1 %6, label %397, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i64, i64* %arg2
+  store i64 %8, i64* %loc1
+  %9 = load i64, i64* %loc1
+  %10 = icmp sgt i64 %9, 16
+  br i1 %10, label %257, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load i64, i64* %loc1
+  %13 = icmp slt i64 %12, 0
+  br i1 %13, label %257, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load i64, i64* %loc1
+  %16 = trunc i64 %15 to i32
+  switch i32 %16, label %17 [
+    i32 0, label %18
+    i32 1, label %19
+    i32 2, label %25
+    i32 3, label %33
+    i32 4, label %48
+    i32 5, label %54
+    i32 6, label %67
+    i32 7, label %82
+    i32 8, label %104
+    i32 9, label %110
+    i32 10, label %123
+    i32 11, label %138
+    i32 12, label %160
+    i32 13, label %173
+    i32 14, label %193
+    i32 15, label %215
+    i32 16, label %244
+  ]
+
+; <label>:17                                      ; preds = %14
+  br label %257
+
+; <label>:18                                      ; preds = %14
+  ret void
+
+; <label>:19                                      ; preds = %14
+  %20 = load i8*, i8** %arg0
+  %21 = load i8*, i8** %arg1
+  %22 = load i8, i8* %21, align 8
+  %23 = zext i8 %22 to i32
+  %24 = trunc i32 %23 to i8
+  store i8 %24, i8* %20, align 8
+  ret void
+
+; <label>:25                                      ; preds = %14
+  %26 = load i8*, i8** %arg0
+  %27 = load i8*, i8** %arg1
+  %28 = bitcast i8* %27 to i16*
+  %29 = load i16, i16* %28, align 8
+  %30 = sext i16 %29 to i32
+  %31 = bitcast i8* %26 to i16*
+  %32 = trunc i32 %30 to i16
+  store i16 %32, i16* %31, align 8
+  ret void
+
+; <label>:33                                      ; preds = %14
+  %34 = load i8*, i8** %arg0
+  %35 = load i8*, i8** %arg1
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = sext i16 %37 to i32
+  %39 = bitcast i8* %34 to i16*
+  %40 = trunc i32 %38 to i16
+  store i16 %40, i16* %39, align 8
+  %41 = load i8*, i8** %arg0
+  %42 = getelementptr inbounds i8, i8* %41, i64 2
+  %43 = load i8*, i8** %arg1
+  %44 = getelementptr inbounds i8, i8* %43, i64 2
+  %45 = load i8, i8* %44, align 8
+  %46 = zext i8 %45 to i32
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %42, align 8
+  ret void
+
+; <label>:48                                      ; preds = %14
+  %49 = load i8*, i8** %arg0
+  %50 = load i8*, i8** %arg1
+  %51 = bitcast i8* %50 to i32*
+  %52 = load i32, i32* %51, align 8
+  %53 = bitcast i8* %49 to i32*
+  store i32 %52, i32* %53, align 8
+  ret void
+
+; <label>:54                                      ; preds = %14
+  %55 = load i8*, i8** %arg0
+  %56 = load i8*, i8** %arg1
+  %57 = bitcast i8* %56 to i32*
+  %58 = load i32, i32* %57, align 8
+  %59 = bitcast i8* %55 to i32*
+  store i32 %58, i32* %59, align 8
+  %60 = load i8*, i8** %arg0
+  %61 = getelementptr inbounds i8, i8* %60, i64 4
+  %62 = load i8*, i8** %arg1
+  %63 = getelementptr inbounds i8, i8* %62, i64 4
+  %64 = load i8, i8* %63, align 8
+  %65 = zext i8 %64 to i32
+  %66 = trunc i32 %65 to i8
+  store i8 %66, i8* %61, align 8
+  ret void
+
+; <label>:67                                      ; preds = %14
+  %68 = load i8*, i8** %arg0
+  %69 = load i8*, i8** %arg1
+  %70 = bitcast i8* %69 to i32*
+  %71 = load i32, i32* %70, align 8
+  %72 = bitcast i8* %68 to i32*
+  store i32 %71, i32* %72, align 8
+  %73 = load i8*, i8** %arg0
+  %74 = getelementptr inbounds i8, i8* %73, i64 4
+  %75 = load i8*, i8** %arg1
+  %76 = getelementptr inbounds i8, i8* %75, i64 4
+  %77 = bitcast i8* %76 to i16*
+  %78 = load i16, i16* %77, align 8
+  %79 = sext i16 %78 to i32
+  %80 = bitcast i8* %74 to i16*
+  %81 = trunc i32 %79 to i16
+  store i16 %81, i16* %80, align 8
+  ret void
+
+; <label>:82                                      ; preds = %14
+  %83 = load i8*, i8** %arg0
+  %84 = load i8*, i8** %arg1
+  %85 = bitcast i8* %84 to i32*
+  %86 = load i32, i32* %85, align 8
+  %87 = bitcast i8* %83 to i32*
+  store i32 %86, i32* %87, align 8
+  %88 = load i8*, i8** %arg0
+  %89 = getelementptr inbounds i8, i8* %88, i64 4
+  %90 = load i8*, i8** %arg1
+  %91 = getelementptr inbounds i8, i8* %90, i64 4
+  %92 = bitcast i8* %91 to i16*
+  %93 = load i16, i16* %92, align 8
+  %94 = sext i16 %93 to i32
+  %95 = bitcast i8* %89 to i16*
+  %96 = trunc i32 %94 to i16
+  store i16 %96, i16* %95, align 8
+  %97 = load i8*, i8** %arg0
+  %98 = getelementptr inbounds i8, i8* %97, i64 6
+  %99 = load i8*, i8** %arg1
+  %100 = getelementptr inbounds i8, i8* %99, i64 6
+  %101 = load i8, i8* %100, align 8
+  %102 = zext i8 %101 to i32
+  %103 = trunc i32 %102 to i8
+  store i8 %103, i8* %98, align 8
+  ret void
+
+; <label>:104                                     ; preds = %14
+  %105 = load i8*, i8** %arg0
+  %106 = load i8*, i8** %arg1
+  %107 = bitcast i8* %106 to i64*
+  %108 = load i64, i64* %107, align 8
+  %109 = bitcast i8* %105 to i64*
+  store i64 %108, i64* %109, align 8
+  ret void
+
+; <label>:110                                     ; preds = %14
+  %111 = load i8*, i8** %arg0
+  %112 = load i8*, i8** %arg1
+  %113 = bitcast i8* %112 to i64*
+  %114 = load i64, i64* %113, align 8
+  %115 = bitcast i8* %111 to i64*
+  store i64 %114, i64* %115, align 8
+  %116 = load i8*, i8** %arg0
+  %117 = getelementptr inbounds i8, i8* %116, i64 8
+  %118 = load i8*, i8** %arg1
+  %119 = getelementptr inbounds i8, i8* %118, i64 8
+  %120 = load i8, i8* %119, align 8
+  %121 = zext i8 %120 to i32
+  %122 = trunc i32 %121 to i8
+  store i8 %122, i8* %117, align 8
+  ret void
+
+; <label>:123                                     ; preds = %14
+  %124 = load i8*, i8** %arg0
+  %125 = load i8*, i8** %arg1
+  %126 = bitcast i8* %125 to i64*
+  %127 = load i64, i64* %126, align 8
+  %128 = bitcast i8* %124 to i64*
+  store i64 %127, i64* %128, align 8
+  %129 = load i8*, i8** %arg0
+  %130 = getelementptr inbounds i8, i8* %129, i64 8
+  %131 = load i8*, i8** %arg1
+  %132 = getelementptr inbounds i8, i8* %131, i64 8
+  %133 = bitcast i8* %132 to i16*
+  %134 = load i16, i16* %133, align 8
+  %135 = sext i16 %134 to i32
+  %136 = bitcast i8* %130 to i16*
+  %137 = trunc i32 %135 to i16
+  store i16 %137, i16* %136, align 8
+  ret void
+
+; <label>:138                                     ; preds = %14
+  %139 = load i8*, i8** %arg0
+  %140 = load i8*, i8** %arg1
+  %141 = bitcast i8* %140 to i64*
+  %142 = load i64, i64* %141, align 8
+  %143 = bitcast i8* %139 to i64*
+  store i64 %142, i64* %143, align 8
+  %144 = load i8*, i8** %arg0
+  %145 = getelementptr inbounds i8, i8* %144, i64 8
+  %146 = load i8*, i8** %arg1
+  %147 = getelementptr inbounds i8, i8* %146, i64 8
+  %148 = bitcast i8* %147 to i16*
+  %149 = load i16, i16* %148, align 8
+  %150 = sext i16 %149 to i32
+  %151 = bitcast i8* %145 to i16*
+  %152 = trunc i32 %150 to i16
+  store i16 %152, i16* %151, align 8
+  %153 = load i8*, i8** %arg0
+  %154 = getelementptr inbounds i8, i8* %153, i64 10
+  %155 = load i8*, i8** %arg1
+  %156 = getelementptr inbounds i8, i8* %155, i64 10
+  %157 = load i8, i8* %156, align 8
+  %158 = zext i8 %157 to i32
+  %159 = trunc i32 %158 to i8
+  store i8 %159, i8* %154, align 8
+  ret void
+
+; <label>:160                                     ; preds = %14
+  %161 = load i8*, i8** %arg0
+  %162 = load i8*, i8** %arg1
+  %163 = bitcast i8* %162 to i64*
+  %164 = load i64, i64* %163, align 8
+  %165 = bitcast i8* %161 to i64*
+  store i64 %164, i64* %165, align 8
+  %166 = load i8*, i8** %arg0
+  %167 = getelementptr inbounds i8, i8* %166, i64 8
+  %168 = load i8*, i8** %arg1
+  %169 = getelementptr inbounds i8, i8* %168, i64 8
+  %170 = bitcast i8* %169 to i32*
+  %171 = load i32, i32* %170, align 8
+  %172 = bitcast i8* %167 to i32*
+  store i32 %171, i32* %172, align 8
+  ret void
+
+; <label>:173                                     ; preds = %14
+  %174 = load i8*, i8** %arg0
+  %175 = load i8*, i8** %arg1
+  %176 = bitcast i8* %175 to i64*
+  %177 = load i64, i64* %176, align 8
+  %178 = bitcast i8* %174 to i64*
+  store i64 %177, i64* %178, align 8
+  %179 = load i8*, i8** %arg0
+  %180 = getelementptr inbounds i8, i8* %179, i64 8
+  %181 = load i8*, i8** %arg1
+  %182 = getelementptr inbounds i8, i8* %181, i64 8
+  %183 = bitcast i8* %182 to i32*
+  %184 = load i32, i32* %183, align 8
+  %185 = bitcast i8* %180 to i32*
+  store i32 %184, i32* %185, align 8
+  %186 = load i8*, i8** %arg0
+  %187 = getelementptr inbounds i8, i8* %186, i64 12
+  %188 = load i8*, i8** %arg1
+  %189 = getelementptr inbounds i8, i8* %188, i64 12
+  %190 = load i8, i8* %189, align 8
+  %191 = zext i8 %190 to i32
+  %192 = trunc i32 %191 to i8
+  store i8 %192, i8* %187, align 8
+  ret void
+
+; <label>:193                                     ; preds = %14
+  %194 = load i8*, i8** %arg0
+  %195 = load i8*, i8** %arg1
+  %196 = bitcast i8* %195 to i64*
+  %197 = load i64, i64* %196, align 8
+  %198 = bitcast i8* %194 to i64*
+  store i64 %197, i64* %198, align 8
+  %199 = load i8*, i8** %arg0
+  %200 = getelementptr inbounds i8, i8* %199, i64 8
+  %201 = load i8*, i8** %arg1
+  %202 = getelementptr inbounds i8, i8* %201, i64 8
+  %203 = bitcast i8* %202 to i32*
+  %204 = load i32, i32* %203, align 8
+  %205 = bitcast i8* %200 to i32*
+  store i32 %204, i32* %205, align 8
+  %206 = load i8*, i8** %arg0
+  %207 = getelementptr inbounds i8, i8* %206, i64 12
+  %208 = load i8*, i8** %arg1
+  %209 = getelementptr inbounds i8, i8* %208, i64 12
+  %210 = bitcast i8* %209 to i16*
+  %211 = load i16, i16* %210, align 8
+  %212 = sext i16 %211 to i32
+  %213 = bitcast i8* %207 to i16*
+  %214 = trunc i32 %212 to i16
+  store i16 %214, i16* %213, align 8
+  ret void
+
+; <label>:215                                     ; preds = %14
+  %216 = load i8*, i8** %arg0
+  %217 = load i8*, i8** %arg1
+  %218 = bitcast i8* %217 to i64*
+  %219 = load i64, i64* %218, align 8
+  %220 = bitcast i8* %216 to i64*
+  store i64 %219, i64* %220, align 8
+  %221 = load i8*, i8** %arg0
+  %222 = getelementptr inbounds i8, i8* %221, i64 8
+  %223 = load i8*, i8** %arg1
+  %224 = getelementptr inbounds i8, i8* %223, i64 8
+  %225 = bitcast i8* %224 to i32*
+  %226 = load i32, i32* %225, align 8
+  %227 = bitcast i8* %222 to i32*
+  store i32 %226, i32* %227, align 8
+  %228 = load i8*, i8** %arg0
+  %229 = getelementptr inbounds i8, i8* %228, i64 12
+  %230 = load i8*, i8** %arg1
+  %231 = getelementptr inbounds i8, i8* %230, i64 12
+  %232 = bitcast i8* %231 to i16*
+  %233 = load i16, i16* %232, align 8
+  %234 = sext i16 %233 to i32
+  %235 = bitcast i8* %229 to i16*
+  %236 = trunc i32 %234 to i16
+  store i16 %236, i16* %235, align 8
+  %237 = load i8*, i8** %arg0
+  %238 = getelementptr inbounds i8, i8* %237, i64 14
+  %239 = load i8*, i8** %arg1
+  %240 = getelementptr inbounds i8, i8* %239, i64 14
+  %241 = load i8, i8* %240, align 8
+  %242 = zext i8 %241 to i32
+  %243 = trunc i32 %242 to i8
+  store i8 %243, i8* %238, align 8
+  ret void
+
+; <label>:244                                     ; preds = %14
+  %245 = load i8*, i8** %arg0
+  %246 = load i8*, i8** %arg1
+  %247 = bitcast i8* %246 to i64*
+  %248 = load i64, i64* %247, align 8
+  %249 = bitcast i8* %245 to i64*
+  store i64 %248, i64* %249, align 8
+  %250 = load i8*, i8** %arg0
+  %251 = getelementptr inbounds i8, i8* %250, i64 8
+  %252 = load i8*, i8** %arg1
+  %253 = getelementptr inbounds i8, i8* %252, i64 8
+  %254 = bitcast i8* %253 to i64*
+  %255 = load i64, i64* %254, align 8
+  %256 = bitcast i8* %251 to i64*
+  store i64 %255, i64* %256, align 8
+  ret void
+
+; <label>:257                                     ; preds = %7, %11, %17
+  %258 = load i64, i64* %arg2
+  %259 = icmp uge i64 %258, 512
+  br i1 %259, label %397, label %260
+
+; <label>:260                                     ; preds = %257
+  %261 = load i8*, i8** %arg0
+  %262 = ptrtoint i8* %261 to i32
+  %263 = and i32 %262, 3
+  %264 = icmp eq i32 %263, 0
+  br i1 %264, label %300, label %265
+
+; <label>:265                                     ; preds = %260
+  %266 = load i8*, i8** %arg0
+  %267 = ptrtoint i8* %266 to i32
+  %268 = and i32 %267, 1
+  %269 = icmp eq i32 %268, 0
+  br i1 %269, label %286, label %270
+
+; <label>:270                                     ; preds = %265
+  %271 = load i8*, i8** %arg0
+  %272 = load i8*, i8** %arg1
+  %273 = load i8, i8* %272, align 8
+  %274 = zext i8 %273 to i32
+  %275 = trunc i32 %274 to i8
+  store i8 %275, i8* %271, align 8
+  %276 = load i8*, i8** %arg1
+  %277 = getelementptr inbounds i8, i8* %276, i64 1
+  store i8* %277, i8** %arg1
+  %278 = load i8*, i8** %arg0
+  %279 = getelementptr inbounds i8, i8* %278, i64 1
+  store i8* %279, i8** %arg0
+  %280 = load i64, i64* %arg2
+  %281 = sub i64 %280, 1
+  store i64 %281, i64* %arg2
+  %282 = load i8*, i8** %arg0
+  %283 = ptrtoint i8* %282 to i32
+  %284 = and i32 %283, 2
+  %285 = icmp eq i32 %284, 0
+  br i1 %285, label %300, label %286
+
+; <label>:286                                     ; preds = %265, %270
+  %287 = load i8*, i8** %arg0
+  %288 = load i8*, i8** %arg1
+  %289 = bitcast i8* %288 to i16*
+  %290 = load i16, i16* %289, align 8
+  %291 = sext i16 %290 to i32
+  %292 = bitcast i8* %287 to i16*
+  %293 = trunc i32 %291 to i16
+  store i16 %293, i16* %292, align 8
+  %294 = load i8*, i8** %arg1
+  %295 = getelementptr inbounds i8, i8* %294, i64 2
+  store i8* %295, i8** %arg1
+  %296 = load i8*, i8** %arg0
+  %297 = getelementptr inbounds i8, i8* %296, i64 2
+  store i8* %297, i8** %arg0
+  %298 = load i64, i64* %arg2
+  %299 = sub i64 %298, 2
+  store i64 %299, i64* %arg2
+  br label %300
+
+; <label>:300                                     ; preds = %260, %270, %286
+  %301 = load i8*, i8** %arg0
+  %302 = ptrtoint i8* %301 to i32
+  %303 = and i32 %302, 4
+  %304 = icmp eq i32 %303, 0
+  br i1 %304, label %317, label %305
+
+; <label>:305                                     ; preds = %300
+  %306 = load i8*, i8** %arg0
+  %307 = load i8*, i8** %arg1
+  %308 = bitcast i8* %307 to i32*
+  %309 = load i32, i32* %308, align 8
+  %310 = bitcast i8* %306 to i32*
+  store i32 %309, i32* %310, align 8
+  %311 = load i8*, i8** %arg1
+  %312 = getelementptr inbounds i8, i8* %311, i64 4
+  store i8* %312, i8** %arg1
+  %313 = load i8*, i8** %arg0
+  %314 = getelementptr inbounds i8, i8* %313, i64 4
+  store i8* %314, i8** %arg0
+  %315 = load i64, i64* %arg2
+  %316 = sub i64 %315, 4
+  store i64 %316, i64* %arg2
+  br label %317
+
+; <label>:317                                     ; preds = %300, %305
+  %318 = load i64, i64* %arg2
+  %319 = udiv i64 %318, 16
+  store i64 %319, i64* %loc0
+  br label %339
+
+; <label>:320                                     ; preds = %339
+  %321 = load i8*, i8** %arg0
+  %322 = load i8*, i8** %arg1
+  %323 = bitcast i8* %322 to i64*
+  %324 = load i64, i64* %323, align 8
+  %325 = bitcast i8* %321 to i64*
+  store i64 %324, i64* %325, align 8
+  %326 = load i8*, i8** %arg0
+  %327 = getelementptr inbounds i8, i8* %326, i64 8
+  %328 = load i8*, i8** %arg1
+  %329 = getelementptr inbounds i8, i8* %328, i64 8
+  %330 = bitcast i8* %329 to i64*
+  %331 = load i64, i64* %330, align 8
+  %332 = bitcast i8* %327 to i64*
+  store i64 %331, i64* %332, align 8
+  %333 = load i8*, i8** %arg0
+  %334 = getelementptr inbounds i8, i8* %333, i64 16
+  store i8* %334, i8** %arg0
+  %335 = load i8*, i8** %arg1
+  %336 = getelementptr inbounds i8, i8* %335, i64 16
+  store i8* %336, i8** %arg1
+  %337 = load i64, i64* %loc0
+  %338 = sub i64 %337, 1
+  store i64 %338, i64* %loc0
+  br label %339
+
+; <label>:339                                     ; preds = %317, %320
+  %340 = load i64, i64* %loc0
+  %341 = icmp ugt i64 %340, 0
+  br i1 %341, label %320, label %342
+
+; <label>:342                                     ; preds = %339
+  %343 = load i64, i64* %arg2
+  %344 = and i64 %343, 8
+  %345 = icmp eq i64 %344, 0
+  br i1 %345, label %356, label %346
+
+; <label>:346                                     ; preds = %342
+  %347 = load i8*, i8** %arg0
+  %348 = load i8*, i8** %arg1
+  %349 = bitcast i8* %348 to i64*
+  %350 = load i64, i64* %349, align 8
+  %351 = bitcast i8* %347 to i64*
+  store i64 %350, i64* %351, align 8
+  %352 = load i8*, i8** %arg0
+  %353 = getelementptr inbounds i8, i8* %352, i64 8
+  store i8* %353, i8** %arg0
+  %354 = load i8*, i8** %arg1
+  %355 = getelementptr inbounds i8, i8* %354, i64 8
+  store i8* %355, i8** %arg1
+  br label %356
+
+; <label>:356                                     ; preds = %342, %346
+  %357 = load i64, i64* %arg2
+  %358 = and i64 %357, 4
+  %359 = icmp eq i64 %358, 0
+  br i1 %359, label %370, label %360
+
+; <label>:360                                     ; preds = %356
+  %361 = load i8*, i8** %arg0
+  %362 = load i8*, i8** %arg1
+  %363 = bitcast i8* %362 to i32*
+  %364 = load i32, i32* %363, align 8
+  %365 = bitcast i8* %361 to i32*
+  store i32 %364, i32* %365, align 8
+  %366 = load i8*, i8** %arg0
+  %367 = getelementptr inbounds i8, i8* %366, i64 4
+  store i8* %367, i8** %arg0
+  %368 = load i8*, i8** %arg1
+  %369 = getelementptr inbounds i8, i8* %368, i64 4
+  store i8* %369, i8** %arg1
+  br label %370
+
+; <label>:370                                     ; preds = %356, %360
+  %371 = load i64, i64* %arg2
+  %372 = and i64 %371, 2
+  %373 = icmp eq i64 %372, 0
+  br i1 %373, label %386, label %374
+
+; <label>:374                                     ; preds = %370
+  %375 = load i8*, i8** %arg0
+  %376 = load i8*, i8** %arg1
+  %377 = bitcast i8* %376 to i16*
+  %378 = load i16, i16* %377, align 8
+  %379 = sext i16 %378 to i32
+  %380 = bitcast i8* %375 to i16*
+  %381 = trunc i32 %379 to i16
+  store i16 %381, i16* %380, align 8
+  %382 = load i8*, i8** %arg0
+  %383 = getelementptr inbounds i8, i8* %382, i64 2
+  store i8* %383, i8** %arg0
+  %384 = load i8*, i8** %arg1
+  %385 = getelementptr inbounds i8, i8* %384, i64 2
+  store i8* %385, i8** %arg1
+  br label %386
+
+; <label>:386                                     ; preds = %370, %374
+  %387 = load i64, i64* %arg2
+  %388 = and i64 %387, 1
+  %389 = icmp eq i64 %388, 0
+  br i1 %389, label %396, label %390
+
+; <label>:390                                     ; preds = %386
+  %391 = load i8*, i8** %arg0
+  %392 = load i8*, i8** %arg1
+  %393 = load i8, i8* %392, align 8
+  %394 = zext i8 %393 to i32
+  %395 = trunc i32 %394 to i8
+  store i8 %395, i8* %391, align 8
+  br label %396
+
+; <label>:396                                     ; preds = %386, %390
+  ret void
+
+; <label>:397                                     ; preds = %entry, %257
+  %398 = load i8*, i8** %arg0
+  %399 = load i8*, i8** %arg1
+  %400 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %398, i8* %399, i64 %400)
+  ret void
+}
+
 INFO:  jitting method String::Concat using LLILCJit
 Successfully read String.Concat
 
@@ -521,7 +1302,261 @@ Failed to read AppDomainSetup..ctor[storeElem]
 INFO:  jitting method List`1::.cctor using LLILCJit
 Failed to read List`1..cctor[callRuntimeHandleHelper]
 INFO:  jitting method String::Compare using LLILCJit
-Failed to read String.Compare[Tail call]
+Successfully read String.Compare
+
+define i32 @String.Compare(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp ule i32 %0, 5
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6, %System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp ne %System.String addrspace(1)* %8, %9
+  br i1 %10, label %12, label %11
+
+; <label>:11                                      ; preds = %7
+  ret i32 0
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %14, label %16, label %15
+
+; <label>:15                                      ; preds = %12
+  ret i32 -1
+
+; <label>:16                                      ; preds = %12
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %18 = icmp ne %System.String addrspace(1)* %17, null
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %16
+  ret i32 1
+
+; <label>:20                                      ; preds = %16
+  %21 = load i32, i32* %arg2
+  store i32 %21, i32* %loc0
+  %22 = load i32, i32* %loc0
+  switch i32 %22, label %23 [
+    i32 0, label %24
+    i32 1, label %48
+    i32 2, label %72
+    i32 3, label %96
+    i32 4, label %120
+    i32 5, label %149
+  ]
+
+; <label>:23                                      ; preds = %20
+  br label %169
+
+; <label>:24                                      ; preds = %20
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
+  %28 = add i64 %27, 72
+  %29 = inttoptr i64 %28 to i64*
+  %30 = load i64, i64* %29
+  %31 = add i64 %30, 16
+  %32 = inttoptr i64 %31 to i64*
+  %33 = load i64, i64* %32
+  %34 = inttoptr i64 %33 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %35 = call %System.Globalization.CompareInfo addrspace(1)* %34(%System.Globalization.CultureInfo addrspace(1)* %25)
+  %36 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %38 = bitcast %System.Globalization.CompareInfo addrspace(1)* %35 to i64 addrspace(1)*
+  %39 = load i64, i64 addrspace(1)* %38
+  %40 = add i64 %39, 64
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = add i64 %42, 48
+  %44 = inttoptr i64 %43 to i64*
+  %45 = load i64, i64* %44
+  %46 = inttoptr i64 %45 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %47 = call i32 %46(%System.Globalization.CompareInfo addrspace(1)* %35, %System.String addrspace(1)* %36, %System.String addrspace(1)* %37, i32 0)
+  ret i32 %47
+
+; <label>:48                                      ; preds = %20
+  %49 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %50 = bitcast %System.Globalization.CultureInfo addrspace(1)* %49 to i64 addrspace(1)*
+  %51 = load i64, i64 addrspace(1)* %50
+  %52 = add i64 %51, 72
+  %53 = inttoptr i64 %52 to i64*
+  %54 = load i64, i64* %53
+  %55 = add i64 %54, 16
+  %56 = inttoptr i64 %55 to i64*
+  %57 = load i64, i64* %56
+  %58 = inttoptr i64 %57 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %59 = call %System.Globalization.CompareInfo addrspace(1)* %58(%System.Globalization.CultureInfo addrspace(1)* %49)
+  %60 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %61 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %62 = bitcast %System.Globalization.CompareInfo addrspace(1)* %59 to i64 addrspace(1)*
+  %63 = load i64, i64 addrspace(1)* %62
+  %64 = add i64 %63, 64
+  %65 = inttoptr i64 %64 to i64*
+  %66 = load i64, i64* %65
+  %67 = add i64 %66, 48
+  %68 = inttoptr i64 %67 to i64*
+  %69 = load i64, i64* %68
+  %70 = inttoptr i64 %69 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %71 = call i32 %70(%System.Globalization.CompareInfo addrspace(1)* %59, %System.String addrspace(1)* %60, %System.String addrspace(1)* %61, i32 1)
+  ret i32 %71
+
+; <label>:72                                      ; preds = %20
+  %73 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %74 = bitcast %System.Globalization.CultureInfo addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
+  %76 = add i64 %75, 72
+  %77 = inttoptr i64 %76 to i64*
+  %78 = load i64, i64* %77
+  %79 = add i64 %78, 16
+  %80 = inttoptr i64 %79 to i64*
+  %81 = load i64, i64* %80
+  %82 = inttoptr i64 %81 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %83 = call %System.Globalization.CompareInfo addrspace(1)* %82(%System.Globalization.CultureInfo addrspace(1)* %73)
+  %84 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %85 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %86 = bitcast %System.Globalization.CompareInfo addrspace(1)* %83 to i64 addrspace(1)*
+  %87 = load i64, i64 addrspace(1)* %86
+  %88 = add i64 %87, 64
+  %89 = inttoptr i64 %88 to i64*
+  %90 = load i64, i64* %89
+  %91 = add i64 %90, 48
+  %92 = inttoptr i64 %91 to i64*
+  %93 = load i64, i64* %92
+  %94 = inttoptr i64 %93 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %95 = call i32 %94(%System.Globalization.CompareInfo addrspace(1)* %83, %System.String addrspace(1)* %84, %System.String addrspace(1)* %85, i32 0)
+  ret i32 %95
+
+; <label>:96                                      ; preds = %20
+  %97 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %98 = bitcast %System.Globalization.CultureInfo addrspace(1)* %97 to i64 addrspace(1)*
+  %99 = load i64, i64 addrspace(1)* %98
+  %100 = add i64 %99, 72
+  %101 = inttoptr i64 %100 to i64*
+  %102 = load i64, i64* %101
+  %103 = add i64 %102, 16
+  %104 = inttoptr i64 %103 to i64*
+  %105 = load i64, i64* %104
+  %106 = inttoptr i64 %105 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %107 = call %System.Globalization.CompareInfo addrspace(1)* %106(%System.Globalization.CultureInfo addrspace(1)* %97)
+  %108 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %109 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %110 = bitcast %System.Globalization.CompareInfo addrspace(1)* %107 to i64 addrspace(1)*
+  %111 = load i64, i64 addrspace(1)* %110
+  %112 = add i64 %111, 64
+  %113 = inttoptr i64 %112 to i64*
+  %114 = load i64, i64* %113
+  %115 = add i64 %114, 48
+  %116 = inttoptr i64 %115 to i64*
+  %117 = load i64, i64* %116
+  %118 = inttoptr i64 %117 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %119 = call i32 %118(%System.Globalization.CompareInfo addrspace(1)* %107, %System.String addrspace(1)* %108, %System.String addrspace(1)* %109, i32 1)
+  ret i32 %119
+
+; <label>:120                                     ; preds = %20
+  %121 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %122 = getelementptr inbounds %System.String, %System.String addrspace(1)* %121, i32 0, i32 2
+  %123 = bitcast [0 x i16] addrspace(1)* %122 to i16 addrspace(1)*
+  %124 = load i16, i16 addrspace(1)* %123, align 8
+  %125 = zext i16 %124 to i32
+  %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %127 = getelementptr inbounds %System.String, %System.String addrspace(1)* %126, i32 0, i32 2
+  %128 = bitcast [0 x i16] addrspace(1)* %127 to i16 addrspace(1)*
+  %129 = load i16, i16 addrspace(1)* %128, align 8
+  %130 = zext i16 %129 to i32
+  %131 = sub i32 %125, %130
+  %132 = icmp eq i32 %131, 0
+  br i1 %132, label %145, label %133
+
+; <label>:133                                     ; preds = %120
+  %134 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %135 = getelementptr inbounds %System.String, %System.String addrspace(1)* %134, i32 0, i32 2
+  %136 = bitcast [0 x i16] addrspace(1)* %135 to i16 addrspace(1)*
+  %137 = load i16, i16 addrspace(1)* %136, align 8
+  %138 = zext i16 %137 to i32
+  %139 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %140 = getelementptr inbounds %System.String, %System.String addrspace(1)* %139, i32 0, i32 2
+  %141 = bitcast [0 x i16] addrspace(1)* %140 to i16 addrspace(1)*
+  %142 = load i16, i16 addrspace(1)* %141, align 8
+  %143 = zext i16 %142 to i32
+  %144 = sub i32 %138, %143
+  ret i32 %144
+
+; <label>:145                                     ; preds = %120
+  %146 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %147 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %148 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %146, %System.String addrspace(1)* %147)
+  ret i32 %148
+
+; <label>:149                                     ; preds = %20
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %150, null
+  br i1 %NullCheck, label %151, label %ThrowNullRef
+
+; <label>:151                                     ; preds = %149
+  %152 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %150)
+  %153 = zext i8 %152 to i32
+  %154 = icmp eq i32 %153, 0
+  br i1 %154, label %165, label %155
+
+; <label>:155                                     ; preds = %151
+  %156 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %156, null
+  br i1 %NullCheck2, label %157, label %ThrowNullRef1
+
+; <label>:157                                     ; preds = %155
+  %158 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %156)
+  %159 = zext i8 %158 to i32
+  %160 = icmp eq i32 %159, 0
+  br i1 %160, label %165, label %161
+
+; <label>:161                                     ; preds = %157
+  %162 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %163 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %164 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %162, %System.String addrspace(1)* %163)
+  ret i32 %164
+
+; <label>:165                                     ; preds = %151, %157
+  %166 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %167 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %168 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %166, %System.String addrspace(1)* %167)
+  ret i32 %168
+
+; <label>:169                                     ; preds = %23
+  %170 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %171 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %170)
+  %172 = call %System.NotSupportedException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NotSupportedException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*, %System.String addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172, %System.String addrspace(1)* %171)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NotSupportedException addrspace(1)*)*)(%System.NotSupportedException addrspace(1)* %172) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %149
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %155
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method String::CompareOrdinalIgnoreCaseHelper using LLILCJit
 Successfully read String.CompareOrdinalIgnoreCaseHelper
 
@@ -689,7 +1724,83 @@ entry:
 INFO:  jitting method List`1::Add using LLILCJit
 Failed to read List`1.Add[storeElem]
 INFO:  jitting method List`1::EnsureCapacity using LLILCJit
-Failed to read List`1.EnsureCapacity[Tail call]
+Successfully read List`1.EnsureCapacity
+
+define void @"List`1.EnsureCapacity"(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca i32
+  %loc0 = alloca i32
+  store %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %0, i32 0, i32 1
+  %2 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = zext i32 %4 to i64
+  %6 = trunc i64 %5 to i32
+  %7 = load i32, i32* %arg1
+  %8 = icmp sge i32 %6, %7
+  br i1 %8, label %42, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %11 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %10, i32 0, i32 1
+  %12 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %11, align 8
+  %13 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = zext i32 %14 to i64
+  %16 = trunc i64 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %27, label %18
+
+; <label>:18                                      ; preds = %9
+  %19 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %20 = getelementptr inbounds %"System.Collections.Generic.List`1[System.__Canon]", %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %19, i32 0, i32 1
+  %21 = load %"System.__Canon[]" addrspace(1)*, %"System.__Canon[]" addrspace(1)* addrspace(1)* %20, align 8
+  %22 = getelementptr inbounds %"System.__Canon[]", %"System.__Canon[]" addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = zext i32 %23 to i64
+  %25 = trunc i64 %24 to i32
+  %26 = mul i32 %25, 2
+  br label %28
+
+; <label>:27                                      ; preds = %9
+  br label %28
+
+; <label>:28                                      ; preds = %18, %27
+  %29 = phi i32 [ %26, %18 ], [ 4, %27 ]
+  store i32 %29, i32* %loc0
+  %30 = load i32, i32* %loc0
+  %31 = icmp ule i32 %30, 2146435071
+  br i1 %31, label %33, label %32
+
+; <label>:32                                      ; preds = %28
+  store i32 2146435071, i32* %loc0
+  br label %33
+
+; <label>:33                                      ; preds = %28, %32
+  %34 = load i32, i32* %loc0
+  %35 = load i32, i32* %arg1
+  %36 = icmp sge i32 %34, %35
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = load i32, i32* %arg1
+  store i32 %38, i32* %loc0
+  br label %39
+
+; <label>:39                                      ; preds = %33, %37
+  %40 = load %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)** %this
+  %41 = load i32, i32* %loc0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*, i32)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %40, i32 %41)
+  br label %42
+
+; <label>:42                                      ; preds = %entry, %39
+  ret void
+}
+
 INFO:  jitting method List`1::set_Capacity using LLILCJit
 Failed to read List`1.set_Capacity[non-const derefAddress]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
@@ -701,7 +1812,7 @@ Failed to read EqualityComparer`1.get_Default[Call HasTypeArg]
 INFO:  jitting method EqualityComparer`1::CreateComparer using LLILCJit
 Failed to read EqualityComparer`1.CreateComparer[conditionalDerefAddress]
 INFO:  jitting method RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read RuntimeType.IsAssignableFrom[Tail call]
+Failed to read RuntimeType.IsAssignableFrom[loadElem]
 INFO:  jitting method RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read RuntimeType.get_UnderlyingSystemType
 
@@ -715,11 +1826,44 @@ entry:
 }
 
 INFO:  jitting method GenericEqualityComparer`1::.ctor using LLILCJit
-Failed to read GenericEqualityComparer`1..ctor[Tail call]
+Successfully read GenericEqualityComparer`1..ctor
+
+define void @"GenericEqualityComparer`1..ctor"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method EqualityComparer`1::.ctor using LLILCJit
+Successfully read EqualityComparer`1..ctor
+
+define void @"EqualityComparer`1..ctor"(%"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)*, %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.Generic.EqualityComparer`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::.cctor using LLILCJit
 Failed to read HashHelpers..cctor[convertHandle]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
-Failed to read String.UseRandomizedHashing[Tail call]
+Successfully read String.UseRandomizedHashing
+
+define i8 @String.UseRandomizedHashing() {
+entry:
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = trunc i32 %1 to i8
+  ret i8 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method List`1::System.Collections.Generic.IEnumerable<T>.GetEnumerator using LLILCJit
@@ -859,7 +2003,7 @@ entry:
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
-Failed to read CultureData.GetCultureData[Tail call]
+Failed to read CultureData.GetCultureData[convertToHelperArgumentType]
 INFO:  jitting method CultureData::get_Invariant using LLILCJit
 Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
@@ -911,11 +2055,109 @@ entry:
 }
 
 INFO:  jitting method String::op_Equality using LLILCJit
-Failed to read String.op_Equality[Tail call]
+Successfully read String.op_Equality
+
+define i8 @String.op_Equality(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1)
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = icmp ne %System.String addrspace(1)* %0, %1
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %6 = icmp eq %System.String addrspace(1)* %5, null
+  br i1 %6, label %10, label %7
+
+; <label>:7                                       ; preds = %4
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %9 = icmp ne %System.String addrspace(1)* %8, null
+  br i1 %9, label %11, label %10
+
+; <label>:10                                      ; preds = %4, %7
+  ret i8 0
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %13 = getelementptr inbounds %System.String, %System.String addrspace(1)* %12, i32 0, i32 1
+  %14 = load i32, i32 addrspace(1)* %13
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 1
+  %17 = load i32, i32 addrspace(1)* %16
+  %18 = icmp eq i32 %14, %17
+  br i1 %18, label %20, label %19
+
+; <label>:19                                      ; preds = %11
+  ret i8 0
+
+; <label>:20                                      ; preds = %11
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %21, %System.String addrspace(1)* %22)
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  ret i8 %25
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultCulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 1024)
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = icmp ne %System.String addrspace(1)* %1, null
+  br i1 %2, label %9, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 2048)
+  store %System.String addrspace(1)* %4, %System.String addrspace(1)** %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %9, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %8
+
+; <label>:9                                       ; preds = %entry, %3
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %11 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %10, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %11, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %13 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %12, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %14
+}
+
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -957,9 +2199,22 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
-Failed to read CultureInfo..ctor[Tail call]
+Successfully read CultureInfo..ctor
+
+define void @CultureInfo..ctor(%System.Globalization.CultureInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 1)
+  ret void
+}
+
 INFO:  jitting method CultureData::AnsiToLower using LLILCJit
-Failed to read CultureData.AnsiToLower[Tail call]
+Failed to read CultureData.AnsiToLower[Phi type mismatch]
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
 Failed to read StringBuilder..ctor[storeElem]
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
@@ -1014,7 +2269,39 @@ ThrowNullRef:                                     ; preds = %entry
 }
 
 INFO:  jitting method CultureData::.ctor using LLILCJit
-Failed to read CultureData..ctor[Tail call]
+Successfully read CultureData..ctor
+
+define void @CultureData..ctor(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 48
+  store i32 -1, i32 addrspace(1)* %1
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %2, i32 0, i32 53
+  store i32 -1, i32 addrspace(1)* %3
+  %4 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %4, i32 0, i32 54
+  store i32 -1, i32 addrspace(1)* %5
+  %6 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %6, i32 0, i32 58
+  store i32 -1, i32 addrspace(1)* %7
+  %8 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %8, i32 0, i32 59
+  store i32 -1, i32 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %10, i32 0, i32 60
+  store i32 -1, i32 addrspace(1)* %11
+  %12 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %12, i32 0, i32 61
+  store i32 -1, i32 addrspace(1)* %13
+  %14 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %15 = bitcast %System.Globalization.CultureData addrspace(1)* %14 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %15)
+  ret void
+}
+
 INFO:  jitting method CultureData::InitCultureData using LLILCJit
 Successfully read CultureData.InitCultureData
 
@@ -1044,11 +2331,200 @@ Failed to read Dictionary`2.Initialize[non-const derefAddress]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Failed to read HashHelpers.GetPrime[loadElem]
 INFO:  jitting method GenericEqualityComparer`1::GetHashCode using LLILCJit
-Failed to read GenericEqualityComparer`1.GetHashCode[Tail call]
+Successfully read GenericEqualityComparer`1.GetHashCode
+
+define i32 @"GenericEqualityComparer`1.GetHashCode"(%"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %System.__Canon addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %System.__Canon addrspace(1)*
+  store %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]" addrspace(1)** %this
+  store %System.__Canon addrspace(1)* %param1, %System.__Canon addrspace(1)** %arg1
+  %0 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)** %arg1
+  %1 = icmp ne %System.__Canon addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret i32 0
+
+; <label>:3                                       ; preds = %entry
+  %4 = addrspacecast %System.__Canon addrspace(1)** %arg1 to %System.__Canon addrspace(1)* addrspace(1)*
+  %5 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
+  %6 = bitcast %System.__Canon addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
+  %8 = add i64 %7, 64
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = add i64 %10, 16
+  %12 = inttoptr i64 %11 to i64*
+  %13 = load i64, i64* %12
+  %14 = bitcast %System.__Canon addrspace(1)* %5 to %System.Object addrspace(1)*
+  %15 = inttoptr i64 %13 to i32 (%System.Object addrspace(1)*)*
+  %16 = call i32 %15(%System.Object addrspace(1)* %14)
+  ret i32 %16
+}
+
 INFO:  jitting method String::GetHashCode using LLILCJit
-Failed to read String.GetHashCode[Tail call]
+Successfully read String.GetHashCode
+
+define i32 @String.GetHashCode(%System.String addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i16*
+  %loc5 = alloca i32
+  %loc6 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 574)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 2104
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %12, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %9 = getelementptr inbounds %System.String, %System.String addrspace(1)* %8, i32 0, i32 1
+  %10 = load i32, i32 addrspace(1)* %9
+  %11 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i32, i64)*)(%System.String addrspace(1)* %7, i32 %10, i64 0)
+  ret i32 %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %13, %System.String addrspace(1)** %loc6
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc6
+  %15 = ptrtoint %System.String addrspace(1)* %14 to i64
+  %16 = icmp eq i64 %15, 0
+  br i1 %16, label %21, label %17
+
+; <label>:17                                      ; preds = %12
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %19 = sext i32 %18 to i64
+  %20 = add i64 %15, %19
+  br label %21
+
+; <label>:21                                      ; preds = %12, %17
+  %22 = phi i64 [ %15, %12 ], [ %20, %17 ]
+  %23 = inttoptr i64 %22 to i16*
+  store i16* %23, i16** %loc0
+  store i32 5381, i32* %loc1
+  %24 = load i32, i32* %loc1
+  store i32 %24, i32* %loc2
+  %25 = load i16*, i16** %loc0
+  store i16* %25, i16** %loc4
+  br label %52
+
+; <label>:26                                      ; preds = %52
+  %27 = load i32, i32* %loc1
+  %28 = shl i32 %27, 5
+  %29 = load i32, i32* %loc1
+  %30 = add i32 %28, %29
+  %31 = load i32, i32* %loc3
+  %32 = xor i32 %30, %31
+  store i32 %32, i32* %loc1
+  %33 = load i16*, i16** %loc4
+  %34 = bitcast i16* %33 to i8*
+  %35 = getelementptr inbounds i8, i8* %34, i64 2
+  %36 = bitcast i8* %35 to i16*
+  %37 = load i16, i16* %36, align 8
+  %38 = zext i16 %37 to i32
+  store i32 %38, i32* %loc3
+  %39 = load i32, i32* %loc3
+  %40 = icmp eq i32 %39, 0
+  br i1 %40, label %58, label %41
+
+; <label>:41                                      ; preds = %26
+  %42 = load i32, i32* %loc2
+  %43 = shl i32 %42, 5
+  %44 = load i32, i32* %loc2
+  %45 = add i32 %43, %44
+  %46 = load i32, i32* %loc3
+  %47 = xor i32 %45, %46
+  store i32 %47, i32* %loc2
+  %48 = load i16*, i16** %loc4
+  %49 = bitcast i16* %48 to i8*
+  %50 = getelementptr inbounds i8, i8* %49, i64 4
+  %51 = bitcast i8* %50 to i16*
+  store i16* %51, i16** %loc4
+  br label %52
+
+; <label>:52                                      ; preds = %21, %41
+  %53 = phi i64 [ %22, %21 ], [ %53, %41 ]
+  %54 = load i16*, i16** %loc4
+  %55 = load i16, i16* %54, align 8
+  %56 = zext i16 %55 to i32
+  store i32 %56, i32* %loc3
+  %57 = icmp ne i32 %56, 0
+  br i1 %57, label %26, label %58
+
+; <label>:58                                      ; preds = %26, %52
+  %59 = phi i64 [ %53, %52 ], [ %53, %26 ]
+  %60 = load i32, i32* %loc1
+  %61 = load i32, i32* %loc2
+  %62 = mul i32 %61, 1566083941
+  %63 = add i32 %60, %62
+  store i32 %63, i32* %loc5
+  br label %64
+
+; <label>:64                                      ; preds = %58
+  %65 = load i32, i32* %loc5
+  ret i32 %65
+}
+
 INFO:  jitting method CultureInfo::InitUserDefaultUICulture using LLILCJit
-Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
+Successfully read CultureInfo.InitUserDefaultUICulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.InitUserDefaultUICulture() {
+entry:
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* ()*)()
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 64
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 40
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %12 = call %System.String addrspace(1)* %11(%System.Globalization.CultureInfo addrspace(1)* %2)
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %18, label %16
+
+; <label>:16                                      ; preds = %entry
+  %17 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+
+; <label>:18                                      ; preds = %entry
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %20 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %19, i8 1)
+  store %System.Globalization.CultureInfo addrspace(1)* %20, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %21 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %22 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %21, null
+  br i1 %22, label %25, label %23
+
+; <label>:23                                      ; preds = %18
+  %24 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %24
+
+; <label>:25                                      ; preds = %18
+  %26 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  %27 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %26, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %27
+  %28 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc1
+  ret %System.Globalization.CultureInfo addrspace(1)* %28
+}
+
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1377,7 +2853,18 @@ entry:
 }
 
 INFO:  jitting method StringComparer::.ctor using LLILCJit
-Failed to read StringComparer..ctor[Tail call]
+Successfully read StringComparer..ctor
+
+define void @StringComparer..ctor(%System.StringComparer addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.StringComparer addrspace(1)*
+  store %System.StringComparer addrspace(1)* %param0, %System.StringComparer addrspace(1)** %this
+  %0 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %this
+  %1 = bitcast %System.StringComparer addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method CultureInfo::get_CompareInfo using LLILCJit
 Successfully read CultureInfo.get_CompareInfo
 
@@ -1449,7 +2936,44 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::get_UseUserOverride using LLILCJit
-Failed to read CultureInfo.get_UseUserOverride[Tail call]
+Successfully read CultureInfo.get_UseUserOverride
+
+define i8 @CultureInfo.get_UseUserOverride(%System.Globalization.CultureInfo addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Globalization.CultureInfo addrspace(1)* %param0, %System.Globalization.CultureInfo addrspace(1)** %this
+  %0 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %0, i32 0, i32 6
+  %2 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)* addrspace(1)* %1, align 8
+  %NullCheck = icmp ne %System.Globalization.CultureData addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.CultureData addrspace(1)* %2)
+  %5 = zext i8 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method CultureData::get_UseUserOverride using LLILCJit
+Successfully read CultureData.get_UseUserOverride
+
+define i8 @CultureData.get_UseUserOverride(%System.Globalization.CultureData addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Globalization.CultureData addrspace(1)*
+  store %System.Globalization.CultureData addrspace(1)* %param0, %System.Globalization.CultureData addrspace(1)** %this
+  %0 = load %System.Globalization.CultureData addrspace(1)*, %System.Globalization.CultureData addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Globalization.CultureData, %System.Globalization.CultureData addrspace(1)* %0, i32 0, i32 62
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Successfully read CompareInfo..ctor
 
@@ -1549,7 +3073,20 @@ entry:
 }
 
 INFO:  jitting method CompareInfo::InternalInitSortHandle using LLILCJit
-Failed to read CompareInfo.InternalInitSortHandle[Tail call]
+Successfully read CompareInfo.InternalInitSortHandle
+
+define i64 @CompareInfo.InternalInitSortHandle(%System.String addrspace(1)* %param0, i64 addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i64 addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i64 addrspace(1)* %param1, i64 addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i64 addrspace(1)*, i64 addrspace(1)** %arg1
+  %2 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (%System.String addrspace(1)*, i64 addrspace(1)*)*)(%System.String addrspace(1)* %0, i64 addrspace(1)* %1)
+  ret i64 %2
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
@@ -1588,7 +3125,105 @@ entry:
 }
 
 INFO:  jitting method OrdinalComparer::Equals using LLILCJit
-Failed to read OrdinalComparer.Equals[Tail call]
+Successfully read OrdinalComparer.Equals
+
+define i8 @OrdinalComparer.Equals(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = bitcast %System.String addrspace(1)* %0 to %System.Object addrspace(1)*
+  %3 = bitcast %System.String addrspace(1)* %1 to %System.Object addrspace(1)*
+  %4 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %2, %System.Object addrspace(1)* %3)
+  %5 = zext i8 %4 to i32
+  %6 = icmp eq i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %entry
+  ret i8 1
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %10 = icmp eq %System.String addrspace(1)* %9, null
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %13 = icmp ne %System.String addrspace(1)* %12, null
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %8, %11
+  ret i8 0
+
+; <label>:15                                      ; preds = %11
+  %16 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %17 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %16, i32 0, i32 1
+  %18 = load i8, i8 addrspace(1)* %17, align 8
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %37, label %21
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %26 = getelementptr inbounds %System.String, %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32, i32 addrspace(1)* %26
+  %28 = icmp eq i32 %24, %27
+  br i1 %28, label %30, label %29
+
+; <label>:29                                      ; preds = %21
+  ret i8 0
+
+; <label>:30                                      ; preds = %21
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %33 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32, i32 5)
+  %34 = icmp eq i32 %33, 0
+  %35 = sext i1 %34 to i32
+  %36 = trunc i32 %35 to i8
+  ret i8 %36
+
+; <label>:37                                      ; preds = %15
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %NullCheck = icmp ne %System.String addrspace(1)* %38, null
+  br i1 %NullCheck, label %40, label %ThrowNullRef
+
+; <label>:40                                      ; preds = %37
+  %41 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %38, %System.String addrspace(1)* %39)
+  %42 = zext i8 %41 to i32
+  %43 = trunc i32 %42 to i8
+  ret i8 %43
+
+ThrowNullRef:                                     ; preds = %37
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Object::ReferenceEquals using LLILCJit
+Successfully read Object.ReferenceEquals
+
+define i8 @Object.ReferenceEquals(%System.Object addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.Object addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %arg0
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = icmp eq %System.Object addrspace(1)* %0, %1
+  %3 = sext i1 %2 to i32
+  %4 = trunc i32 %3 to i8
+  ret i8 %4
+}
+
 INFO:  jitting method Enumerator::MoveNextRare using LLILCJit
 Successfully read Enumerator.MoveNextRare
 
@@ -1771,7 +3406,7 @@ Failed to read AppDomainSetup.get_TargetFrameworkName[convertHandle]
 INFO:  jitting method Path::.cctor using LLILCJit
 Failed to read Path..cctor[convertHandle]
 INFO:  jitting method String::SplitInternal using LLILCJit
-Failed to read String.SplitInternal[Tail call]
+Failed to read String.SplitInternal[storeElem]
 INFO:  jitting method String::MakeSeparatorList using LLILCJit
 Failed to read String.MakeSeparatorList[loadElemA]
 INFO:  jitting method String::InternalSplitKeepEmptyEntries using LLILCJit
@@ -1882,7 +3517,50 @@ Failed to read Path.NormalizePath[entryLabel]
 INFO:  jitting method String::TrimHelper using LLILCJit
 Failed to read String.TrimHelper[loadElem]
 INFO:  jitting method String::CreateTrimmedString using LLILCJit
-Failed to read String.CreateTrimmedString[Tail call]
+Successfully read String.CreateTrimmedString
+
+define %System.String addrspace(1)* @String.CreateTrimmedString(%System.String addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = load i32, i32* %arg1
+  %2 = sub i32 %0, %1
+  %3 = add i32 %2, 1
+  store i32 %3, i32* %loc0
+  %4 = load i32, i32* %loc0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %6 = getelementptr inbounds %System.String, %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32, i32 addrspace(1)* %6
+  %8 = icmp ne i32 %4, %7
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load i32, i32* %loc0
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %11
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %15
+
+; <label>:16                                      ; preds = %11
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %18 = load i32, i32* %arg1
+  %19 = load i32, i32* %loc0
+  %20 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %17, i32 %18, i32 %19)
+  ret %System.String addrspace(1)* %20
+}
+
 INFO:  jitting method Path::CheckInvalidPathChars using LLILCJit
 Successfully read Path.CheckInvalidPathChars
 
@@ -1985,7 +3663,23 @@ ThrowNullRef1:                                    ; preds = %16
 }
 
 INFO:  jitting method String::IndexOfAny using LLILCJit
-Failed to read String.IndexOfAny[Tail call]
+Successfully read String.IndexOfAny
+
+define i32 @String.IndexOfAny(%System.String addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32)*)(%System.String addrspace(1)* %0, %"System.Char[]" addrspace(1)* %1, i32 0, i32 %4)
+  ret i32 %5
+}
+
 INFO:  jitting method PathHelper::Append using LLILCJit
 Successfully read PathHelper.Append
 
@@ -2018,7 +3712,7 @@ entry:
   %14 = load i8, i8 addrspace(1)* %13, align 8
   %15 = zext i8 %14 to i32
   %16 = icmp eq i32 %15, 0
-  br i1 %16, label %35, label %17
+  br i1 %16, label %36, label %17
 
 ; <label>:17                                      ; preds = %11
   %18 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
@@ -2032,39 +3726,245 @@ entry:
   %26 = getelementptr inbounds i8, i8* %25, i64 %24
   %27 = load i16, i16* %arg1
   %28 = zext i16 %27 to i32
-  %29 = bitcast i8* %26 to i32*
-  store i32 %28, i32* %29, align 8
-  %30 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %31 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  %32 = load i32, i32 addrspace(1)* %31, align 8
-  %33 = add i32 %32, 1
-  %34 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %30, i32 0, i32 3
-  store i32 %33, i32 addrspace(1)* %34
+  %29 = bitcast i8* %26 to i16*
+  %30 = trunc i32 %28 to i16
+  store i16 %30, i16* %29, align 8
+  %31 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %32 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  %33 = load i32, i32 addrspace(1)* %32, align 8
+  %34 = add i32 %33, 1
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %31, i32 0, i32 3
+  store i32 %34, i32 addrspace(1)* %35
   ret void
 
-; <label>:35                                      ; preds = %11
-  %36 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
-  %37 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %36, i32 0, i32 0
-  %38 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %37, align 8
-  %39 = load i16, i16* %arg1
-  %40 = zext i16 %39 to i32
-  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %38, null
-  br i1 %NullCheck, label %41, label %ThrowNullRef
+; <label>:36                                      ; preds = %11
+  %37 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %38 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %37, i32 0, i32 0
+  %39 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %38, align 8
+  %40 = load i16, i16* %arg1
+  %41 = zext i16 %40 to i32
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %39, null
+  br i1 %NullCheck, label %42, label %ThrowNullRef
 
-; <label>:41                                      ; preds = %35
-  %42 = trunc i32 %40 to i16
-  %43 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %38, i16 %42)
+; <label>:42                                      ; preds = %36
+  %43 = trunc i32 %41 to i16
+  %44 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16)*)(%System.Text.StringBuilder addrspace(1)* %39, i16 %43)
   ret void
 
-ThrowNullRef:                                     ; preds = %35
+ThrowNullRef:                                     ; preds = %36
   call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
   unreachable
 }
 
 INFO:  jitting method PathHelper::get_Length using LLILCJit
-Failed to read PathHelper.get_Length[Tail call]
+Successfully read PathHelper.get_Length
+
+define i32 @PathHelper.get_Length(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %9, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 3
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  ret i32 %8
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %11 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %10, i32 0, i32 0
+  %12 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %11, align 8
+  %NullCheck = icmp ne %System.Text.StringBuilder addrspace(1)* %12, null
+  br i1 %NullCheck, label %13, label %ThrowNullRef
+
+; <label>:13                                      ; preds = %9
+  %14 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %12)
+  ret i32 %14
+
+ThrowNullRef:                                     ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::OrdinalStartsWith using LLILCJit
-Failed to read PathHelper.OrdinalStartsWith[Tail call]
+Successfully read PathHelper.OrdinalStartsWith
+
+define i8 @PathHelper.OrdinalStartsWith(%System.IO.PathHelper addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %loc0 = alloca %System.String addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %0)
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = getelementptr inbounds %System.String, %System.String addrspace(1)* %2, i32 0, i32 1
+  %4 = load i32, i32 addrspace(1)* %3
+  %5 = icmp sge i32 %1, %4
+  br i1 %5, label %7, label %6
+
+; <label>:6                                       ; preds = %entry
+  ret i8 0
+
+; <label>:7                                       ; preds = %entry
+  %8 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %9 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %8, i32 0, i32 5
+  %10 = load i8, i8 addrspace(1)* %9, align 8
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %62, label %13
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %14)
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %32, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %20 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %19, i32 0, i32 1
+  %21 = load i16*, i16* addrspace(1)* %20, align 8
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %23 = getelementptr inbounds %System.String, %System.String addrspace(1)* %22, i32 0, i32 1
+  %24 = load i32, i32 addrspace(1)* %23
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %21, i32 0, i32 %24)
+  store %System.String addrspace(1)* %25, %System.String addrspace(1)** %loc0
+  %26 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.String addrspace(1)* %26, null
+  br i1 %NullCheck, label %28, label %ThrowNullRef
+
+; <label>:28                                      ; preds = %18
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %26, %System.String addrspace(1)* %27, i32 5)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+
+; <label>:32                                      ; preds = %13
+  store i32 0, i32* %loc1
+  br label %55
+
+; <label>:33                                      ; preds = %55
+  %34 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %35 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %34, i32 0, i32 1
+  %36 = load i16*, i16* addrspace(1)* %35, align 8
+  %37 = load i32, i32* %loc1
+  %38 = sext i32 %37 to i64
+  %39 = mul i64 %38, 2
+  %40 = bitcast i16* %36 to i8*
+  %41 = getelementptr inbounds i8, i8* %40, i64 %39
+  %42 = bitcast i8* %41 to i16*
+  %43 = load i16, i16* %42, align 8
+  %44 = zext i16 %43 to i32
+  %45 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %46 = load i32, i32* %loc1
+  %47 = getelementptr inbounds %System.String, %System.String addrspace(1)* %45, i32 0, i32 2, i32 %46
+  %48 = load i16, i16 addrspace(1)* %47
+  %49 = zext i16 %48 to i32
+  %50 = icmp eq i32 %44, %49
+  br i1 %50, label %52, label %51
+
+; <label>:51                                      ; preds = %33
+  ret i8 0
+
+; <label>:52                                      ; preds = %33
+  %53 = load i32, i32* %loc1
+  %54 = add i32 %53, 1
+  store i32 %54, i32* %loc1
+  br label %55
+
+; <label>:55                                      ; preds = %32, %52
+  %56 = load i32, i32* %loc1
+  %57 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %58 = getelementptr inbounds %System.String, %System.String addrspace(1)* %57, i32 0, i32 1
+  %59 = load i32, i32 addrspace(1)* %58
+  %60 = icmp slt i32 %56, %59
+  br i1 %60, label %33, label %61
+
+; <label>:61                                      ; preds = %55
+  ret i8 1
+
+; <label>:62                                      ; preds = %7
+  %63 = load i8, i8* %arg2
+  %64 = zext i8 %63 to i32
+  %65 = icmp eq i32 %64, 0
+  br i1 %65, label %86, label %66
+
+; <label>:66                                      ; preds = %62
+  %67 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %68 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %67, i32 0, i32 0
+  %69 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %68, align 8
+  %70 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to i64 addrspace(1)*
+  %71 = load i64, i64 addrspace(1)* %70
+  %72 = add i64 %71, 64
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = add i64 %74, 0
+  %76 = inttoptr i64 %75 to i64*
+  %77 = load i64, i64* %76
+  %78 = bitcast %System.Text.StringBuilder addrspace(1)* %69 to %System.Object addrspace(1)*
+  %79 = inttoptr i64 %77 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %80 = call %System.String addrspace(1)* %79(%System.Object addrspace(1)* %78)
+  %81 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %80, null
+  br i1 %NullCheck2, label %82, label %ThrowNullRef1
+
+; <label>:82                                      ; preds = %66
+  %83 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %80, %System.String addrspace(1)* %81, i32 5)
+  %84 = zext i8 %83 to i32
+  %85 = trunc i32 %84 to i8
+  ret i8 %85
+
+; <label>:86                                      ; preds = %62
+  %87 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %88 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %87, i32 0, i32 0
+  %89 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %88, align 8
+  %90 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to i64*
+  %94 = load i64, i64* %93
+  %95 = add i64 %94, 0
+  %96 = inttoptr i64 %95 to i64*
+  %97 = load i64, i64* %96
+  %98 = bitcast %System.Text.StringBuilder addrspace(1)* %89 to %System.Object addrspace(1)*
+  %99 = inttoptr i64 %97 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %100 = call %System.String addrspace(1)* %99(%System.Object addrspace(1)* %98)
+  %101 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %100, null
+  br i1 %NullCheck4, label %102, label %ThrowNullRef3
+
+; <label>:102                                     ; preds = %86
+  %103 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*, i32)*)(%System.String addrspace(1)* %100, %System.String addrspace(1)* %101, i32 4)
+  %104 = zext i8 %103 to i32
+  %105 = trunc i32 %104 to i8
+  ret i8 %105
+
+ThrowNullRef:                                     ; preds = %18
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %66
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %86
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PathHelper::NullTerminate using LLILCJit
 Successfully read PathHelper.NullTerminate
 
@@ -2082,8 +3982,8 @@ entry:
   %7 = mul i64 %6, 2
   %8 = bitcast i16* %2 to i8*
   %9 = getelementptr inbounds i8, i8* %8, i64 %7
-  %10 = bitcast i8* %9 to i32*
-  store i32 0, i32* %10, align 8
+  %10 = bitcast i8* %9 to i16*
+  store i16 0, i16* %10, align 8
   ret void
 }
 
@@ -2092,7 +3992,46 @@ Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
-Failed to read PathHelper.ToString[Tail call]
+Successfully read PathHelper.ToString
+
+define %System.String addrspace(1)* @PathHelper.ToString(%System.IO.PathHelper addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.PathHelper addrspace(1)*
+  store %System.IO.PathHelper addrspace(1)* %param0, %System.IO.PathHelper addrspace(1)** %this
+  %0 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %0, i32 0, i32 5
+  %2 = load i8, i8 addrspace(1)* %1, align 8
+  %3 = zext i8 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  br i1 %4, label %12, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %6, i32 0, i32 1
+  %8 = load i16*, i16* addrspace(1)* %7, align 8
+  %9 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.IO.PathHelper addrspace(1)*)*)(%System.IO.PathHelper addrspace(1)* %9)
+  %11 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i16*, i32, i32)*)(%System.String addrspace(1)* null, i16* %8, i32 0, i32 %10)
+  ret %System.String addrspace(1)* %11
+
+; <label>:12                                      ; preds = %entry
+  %13 = load %System.IO.PathHelper addrspace(1)*, %System.IO.PathHelper addrspace(1)** %this
+  %14 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %13, i32 0, i32 0
+  %15 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %14, align 8
+  %16 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 0
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.Text.StringBuilder addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
+  %26 = call %System.String addrspace(1)* %25(%System.Object addrspace(1)* %24)
+  ret %System.String addrspace(1)* %26
+}
+
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
 Successfully read String.CtorCharPtrStartLength
 
@@ -2220,7 +4159,281 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32, i32* %arg2
+  %1 = icmp slt i32 %0, 0
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load i32, i32* %arg2
+  %4 = icmp sle i32 %3, 5
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry, %2
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %6)
+  %8 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %9 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9, %System.String addrspace(1)* %7, %System.String addrspace(1)* %8)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %9) #0
+  unreachable
+
+; <label>:10                                      ; preds = %2
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = icmp ne %System.String addrspace(1)* %11, %12
+  br i1 %13, label %15, label %14
+
+; <label>:14                                      ; preds = %10
+  ret i8 1
+
+; <label>:15                                      ; preds = %10
+  %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  br i1 %17, label %21, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %20 = icmp ne %System.String addrspace(1)* %19, null
+  br i1 %20, label %22, label %21
+
+; <label>:21                                      ; preds = %15, %18
+  ret i8 0
+
+; <label>:22                                      ; preds = %18
+  %23 = load i32, i32* %arg2
+  store i32 %23, i32* %loc0
+  %24 = load i32, i32* %loc0
+  switch i32 %24, label %25 [
+    i32 0, label %26
+    i32 1, label %53
+    i32 2, label %80
+    i32 3, label %107
+    i32 4, label %134
+    i32 5, label %149
+  ]
+
+; <label>:25                                      ; preds = %22
+  br label %184
+
+; <label>:26                                      ; preds = %22
+  %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
+  %29 = load i64, i64 addrspace(1)* %28
+  %30 = add i64 %29, 72
+  %31 = inttoptr i64 %30 to i64*
+  %32 = load i64, i64* %31
+  %33 = add i64 %32, 16
+  %34 = inttoptr i64 %33 to i64*
+  %35 = load i64, i64* %34
+  %36 = inttoptr i64 %35 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %37 = call %System.Globalization.CompareInfo addrspace(1)* %36(%System.Globalization.CultureInfo addrspace(1)* %27)
+  %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %40 = bitcast %System.Globalization.CompareInfo addrspace(1)* %37 to i64 addrspace(1)*
+  %41 = load i64, i64 addrspace(1)* %40
+  %42 = add i64 %41, 64
+  %43 = inttoptr i64 %42 to i64*
+  %44 = load i64, i64* %43
+  %45 = add i64 %44, 48
+  %46 = inttoptr i64 %45 to i64*
+  %47 = load i64, i64* %46
+  %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %37, %System.String addrspace(1)* %38, %System.String addrspace(1)* %39, i32 0)
+  %50 = icmp eq i32 %49, 0
+  %51 = sext i1 %50 to i32
+  %52 = trunc i32 %51 to i8
+  ret i8 %52
+
+; <label>:53                                      ; preds = %22
+  %54 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %55 = bitcast %System.Globalization.CultureInfo addrspace(1)* %54 to i64 addrspace(1)*
+  %56 = load i64, i64 addrspace(1)* %55
+  %57 = add i64 %56, 72
+  %58 = inttoptr i64 %57 to i64*
+  %59 = load i64, i64* %58
+  %60 = add i64 %59, 16
+  %61 = inttoptr i64 %60 to i64*
+  %62 = load i64, i64* %61
+  %63 = inttoptr i64 %62 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %64 = call %System.Globalization.CompareInfo addrspace(1)* %63(%System.Globalization.CultureInfo addrspace(1)* %54)
+  %65 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %66 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %67 = bitcast %System.Globalization.CompareInfo addrspace(1)* %64 to i64 addrspace(1)*
+  %68 = load i64, i64 addrspace(1)* %67
+  %69 = add i64 %68, 64
+  %70 = inttoptr i64 %69 to i64*
+  %71 = load i64, i64* %70
+  %72 = add i64 %71, 48
+  %73 = inttoptr i64 %72 to i64*
+  %74 = load i64, i64* %73
+  %75 = inttoptr i64 %74 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %76 = call i32 %75(%System.Globalization.CompareInfo addrspace(1)* %64, %System.String addrspace(1)* %65, %System.String addrspace(1)* %66, i32 1)
+  %77 = icmp eq i32 %76, 0
+  %78 = sext i1 %77 to i32
+  %79 = trunc i32 %78 to i8
+  ret i8 %79
+
+; <label>:80                                      ; preds = %22
+  %81 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %82 = bitcast %System.Globalization.CultureInfo addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
+  %84 = add i64 %83, 72
+  %85 = inttoptr i64 %84 to i64*
+  %86 = load i64, i64* %85
+  %87 = add i64 %86, 16
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = inttoptr i64 %89 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %91 = call %System.Globalization.CompareInfo addrspace(1)* %90(%System.Globalization.CultureInfo addrspace(1)* %81)
+  %92 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %93 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %94 = bitcast %System.Globalization.CompareInfo addrspace(1)* %91 to i64 addrspace(1)*
+  %95 = load i64, i64 addrspace(1)* %94
+  %96 = add i64 %95, 64
+  %97 = inttoptr i64 %96 to i64*
+  %98 = load i64, i64* %97
+  %99 = add i64 %98, 48
+  %100 = inttoptr i64 %99 to i64*
+  %101 = load i64, i64* %100
+  %102 = inttoptr i64 %101 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %103 = call i32 %102(%System.Globalization.CompareInfo addrspace(1)* %91, %System.String addrspace(1)* %92, %System.String addrspace(1)* %93, i32 0)
+  %104 = icmp eq i32 %103, 0
+  %105 = sext i1 %104 to i32
+  %106 = trunc i32 %105 to i8
+  ret i8 %106
+
+; <label>:107                                     ; preds = %22
+  %108 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %109 = bitcast %System.Globalization.CultureInfo addrspace(1)* %108 to i64 addrspace(1)*
+  %110 = load i64, i64 addrspace(1)* %109
+  %111 = add i64 %110, 72
+  %112 = inttoptr i64 %111 to i64*
+  %113 = load i64, i64* %112
+  %114 = add i64 %113, 16
+  %115 = inttoptr i64 %114 to i64*
+  %116 = load i64, i64* %115
+  %117 = inttoptr i64 %116 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
+  %118 = call %System.Globalization.CompareInfo addrspace(1)* %117(%System.Globalization.CultureInfo addrspace(1)* %108)
+  %119 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %120 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %121 = bitcast %System.Globalization.CompareInfo addrspace(1)* %118 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
+  %123 = add i64 %122, 64
+  %124 = inttoptr i64 %123 to i64*
+  %125 = load i64, i64* %124
+  %126 = add i64 %125, 48
+  %127 = inttoptr i64 %126 to i64*
+  %128 = load i64, i64* %127
+  %129 = inttoptr i64 %128 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
+  %130 = call i32 %129(%System.Globalization.CompareInfo addrspace(1)* %118, %System.String addrspace(1)* %119, %System.String addrspace(1)* %120, i32 1)
+  %131 = icmp eq i32 %130, 0
+  %132 = sext i1 %131 to i32
+  %133 = trunc i32 %132 to i8
+  ret i8 %133
+
+; <label>:134                                     ; preds = %22
+  %135 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %136 = getelementptr inbounds %System.String, %System.String addrspace(1)* %135, i32 0, i32 1
+  %137 = load i32, i32 addrspace(1)* %136
+  %138 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %139 = getelementptr inbounds %System.String, %System.String addrspace(1)* %138, i32 0, i32 1
+  %140 = load i32, i32 addrspace(1)* %139
+  %141 = icmp eq i32 %137, %140
+  br i1 %141, label %143, label %142
+
+; <label>:142                                     ; preds = %134
+  ret i8 0
+
+; <label>:143                                     ; preds = %134
+  %144 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %145 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %146 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %144, %System.String addrspace(1)* %145)
+  %147 = zext i8 %146 to i32
+  %148 = trunc i32 %147 to i8
+  ret i8 %148
+
+; <label>:149                                     ; preds = %22
+  %150 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %151 = getelementptr inbounds %System.String, %System.String addrspace(1)* %150, i32 0, i32 1
+  %152 = load i32, i32 addrspace(1)* %151
+  %153 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %154 = getelementptr inbounds %System.String, %System.String addrspace(1)* %153, i32 0, i32 1
+  %155 = load i32, i32 addrspace(1)* %154
+  %156 = icmp eq i32 %152, %155
+  br i1 %156, label %158, label %157
+
+; <label>:157                                     ; preds = %149
+  ret i8 0
+
+; <label>:158                                     ; preds = %149
+  %159 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %NullCheck = icmp ne %System.String addrspace(1)* %159, null
+  br i1 %NullCheck, label %160, label %ThrowNullRef
+
+; <label>:160                                     ; preds = %158
+  %161 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %159)
+  %162 = zext i8 %161 to i32
+  %163 = icmp eq i32 %162, 0
+  br i1 %163, label %177, label %164
+
+; <label>:164                                     ; preds = %160
+  %165 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %165, null
+  br i1 %NullCheck2, label %166, label %ThrowNullRef1
+
+; <label>:166                                     ; preds = %164
+  %167 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %165)
+  %168 = zext i8 %167 to i32
+  %169 = icmp eq i32 %168, 0
+  br i1 %169, label %177, label %170
+
+; <label>:170                                     ; preds = %166
+  %171 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %172 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %173 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %171, %System.String addrspace(1)* %172)
+  %174 = icmp eq i32 %173, 0
+  %175 = sext i1 %174 to i32
+  %176 = trunc i32 %175 to i8
+  ret i8 %176
+
+; <label>:177                                     ; preds = %160, %166
+  %178 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %179 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %180 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %178, %System.String addrspace(1)* %179)
+  %181 = icmp eq i32 %180, 0
+  %182 = sext i1 %181 to i32
+  %183 = trunc i32 %182 to i8
+  ret i8 %183
+
+; <label>:184                                     ; preds = %25
+  %185 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %186 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %185)
+  %187 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %188 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188, %System.String addrspace(1)* %186, %System.String addrspace(1)* %187)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %188) #0
+  unreachable
+
+ThrowNullRef:                                     ; preds = %158
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %164
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method StringBuilder::Append using LLILCJit
 Failed to read StringBuilder.Append[storeElem]
 INFO:  jitting method StringBuilder::AppendHelper using LLILCJit
@@ -2657,11 +4870,217 @@ entry:
 }
 
 INFO:  jitting method StringBuilder::Remove using LLILCJit
-Failed to read StringBuilder.Remove[Tail call]
+Successfully read StringBuilder.Remove
+
+define void @StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, i32 addrspace(1)* %param4) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %arg3 = alloca %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %arg4 = alloca i32 addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc2 = alloca i32
+  %loc3 = alloca i32
+  %loc4 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  store %System.Text.StringBuilder addrspace(1)* addrspace(1)* %param3, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
+  %0 = load i32, i32* %arg1
+  %1 = load i32, i32* %arg2
+  %2 = add i32 %0, %1
+  store i32 %2, i32* %loc0
+  %3 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %4 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %3, %System.Text.StringBuilder addrspace(1)* %4)
+  store %System.Text.StringBuilder addrspace(1)* null, %System.Text.StringBuilder addrspace(1)** %loc1
+  store i32 0, i32* %loc2
+  br label %5
+
+; <label>:5                                       ; preds = %48, %entry
+  %6 = load i32, i32* %loc0
+  %7 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %8 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %7, align 8
+  %9 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %8, i32 0, i32 4
+  %10 = load i32, i32 addrspace(1)* %9, align 8
+  %11 = sub i32 %6, %10
+  %12 = icmp slt i32 %11, 0
+  br i1 %12, label %40, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %15 = icmp ne %System.Text.StringBuilder addrspace(1)* %14, null
+  br i1 %15, label %24, label %16
+
+; <label>:16                                      ; preds = %13
+  %17 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
+  store %System.Text.StringBuilder addrspace(1)* %18, %System.Text.StringBuilder addrspace(1)** %loc1
+  %19 = load i32, i32* %loc0
+  %20 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %21 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %20, i32 0, i32 4
+  %22 = load i32, i32 addrspace(1)* %21, align 8
+  %23 = sub i32 %19, %22
+  store i32 %23, i32* %loc2
+  br label %24
+
+; <label>:24                                      ; preds = %13, %16
+  %25 = load i32, i32* %arg1
+  %26 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %27 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %26, align 8
+  %28 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 4
+  %29 = load i32, i32 addrspace(1)* %28, align 8
+  %30 = sub i32 %25, %29
+  %31 = icmp slt i32 %30, 0
+  br i1 %31, label %48, label %32
+
+; <label>:32                                      ; preds = %24
+  %33 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %34 = load i32, i32* %arg1
+  %35 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %36 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %35, align 8
+  %37 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %36, i32 0, i32 4
+  %38 = load i32, i32 addrspace(1)* %37, align 8
+  %39 = sub i32 %34, %38
+  store i32 %39, i32 addrspace(1)* %33, align 8
+  br label %54
+
+; <label>:40                                      ; preds = %5
+  %41 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %42 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %41, align 8
+  %43 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  %44 = load i32, i32 addrspace(1)* %43, align 8
+  %45 = load i32, i32* %arg2
+  %46 = sub i32 %44, %45
+  %47 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 4
+  store i32 %46, i32 addrspace(1)* %47
+  br label %48
+
+; <label>:48                                      ; preds = %24, %40
+  %49 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %50 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %51 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %50, align 8
+  %52 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %51, i32 0, i32 2
+  %53 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %52, align 8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %49, %System.Text.StringBuilder addrspace(1)* %53)
+  br label %5
+
+; <label>:54                                      ; preds = %32
+  %55 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %56 = load i32, i32 addrspace(1)* %55, align 8
+  store i32 %56, i32* %loc3
+  %57 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %58 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  %59 = load i32, i32 addrspace(1)* %58, align 8
+  %60 = load i32, i32* %loc2
+  %61 = sub i32 %59, %60
+  store i32 %61, i32* %loc4
+  %62 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %63 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %64 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %63, align 8
+  %65 = icmp eq %System.Text.StringBuilder addrspace(1)* %62, %64
+  br i1 %65, label %99, label %66
+
+; <label>:66                                      ; preds = %54
+  store i32 0, i32* %loc3
+  %67 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %68 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %70 = load i32, i32 addrspace(1)* %69, align 8
+  %71 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %68, i32 0, i32 3
+  store i32 %70, i32 addrspace(1)* %71
+  %72 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %73 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %74 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %73, align 8
+  %75 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %75, %System.Text.StringBuilder addrspace(1)* %74)
+  %76 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %77 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
+  %79 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %78, i32 0, i32 4
+  %80 = load i32, i32 addrspace(1)* %79, align 8
+  %81 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %82 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %81, align 8
+  %83 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %82, i32 0, i32 3
+  %84 = load i32, i32 addrspace(1)* %83, align 8
+  %85 = add i32 %80, %84
+  %86 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %76, i32 0, i32 4
+  store i32 %85, i32 addrspace(1)* %86
+  %87 = load i32 addrspace(1)*, i32 addrspace(1)** %arg4
+  %88 = load i32, i32 addrspace(1)* %87, align 8
+  %89 = icmp ne i32 %88, 0
+  br i1 %89, label %99, label %90
+
+; <label>:90                                      ; preds = %66
+  %91 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %92 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %93 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %92, align 8
+  %94 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %93, i32 0, i32 2
+  %95 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %94, align 8
+  %96 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %91, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %96, %System.Text.StringBuilder addrspace(1)* %95)
+  %97 = load %System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)** %arg3
+  %98 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)* addrspace(1)*, %System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* addrspace(1)* %97, %System.Text.StringBuilder addrspace(1)* %98)
+  br label %99
+
+; <label>:99                                      ; preds = %54, %66, %90
+  %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %101 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  %102 = load i32, i32 addrspace(1)* %101, align 8
+  %103 = load i32, i32* %loc2
+  %104 = load i32, i32* %loc3
+  %105 = sub i32 %103, %104
+  %106 = sub i32 %102, %105
+  %107 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %100, i32 0, i32 3
+  store i32 %106, i32 addrspace(1)* %107
+  %108 = load i32, i32* %loc3
+  %109 = load i32, i32* %loc2
+  %110 = icmp eq i32 %108, %109
+  br i1 %110, label %121, label %111
+
+; <label>:111                                     ; preds = %99
+  %112 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %113 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %112, i32 0, i32 1
+  %114 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %113, align 8
+  %115 = load i32, i32* %loc2
+  %116 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc1
+  %117 = getelementptr inbounds %System.Text.StringBuilder, %System.Text.StringBuilder addrspace(1)* %116, i32 0, i32 1
+  %118 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %117, align 8
+  %119 = load i32, i32* %loc3
+  %120 = load i32, i32* %loc4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Char[]" addrspace(1)*, i32, %"System.Char[]" addrspace(1)*, i32, i32)*)(%"System.Char[]" addrspace(1)* %114, i32 %115, %"System.Char[]" addrspace(1)* %118, i32 %119, i32 %120)
+  br label %121
+
+; <label>:121                                     ; preds = %99, %111
+  ret void
+}
+
 INFO:  jitting method StringBuilder::ThreadSafeCopy using LLILCJit
 Failed to read StringBuilder.ThreadSafeCopy[loadElemA]
 INFO:  jitting method Buffer::_Memmove using LLILCJit
-Failed to read Buffer._Memmove[Tail call]
+Successfully read Buffer._Memmove
+
+define void @Buffer._Memmove(i8* %param0, i8* %param1, i64 %param2) {
+entry:
+  %arg0 = alloca i8*
+  %arg1 = alloca i8*
+  %arg2 = alloca i64
+  store i8* %param0, i8** %arg0
+  store i8* %param1, i8** %arg1
+  store i64 %param2, i64* %arg2
+  %0 = load i8*, i8** %arg0
+  %1 = load i8*, i8** %arg1
+  %2 = load i64, i64* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8*, i8*, i64)*)(i8* %0, i8* %1, i64 %2)
+  ret void
+}
+
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetDataHelper using LLILCJit
 Failed to read AppDomain.SetDataHelper[loadElem]
 INFO:  jitting method AppDomain::get_LocalStore using LLILCJit
@@ -2697,17 +5116,106 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[Tail call]
+Successfully read Dictionary`2..ctor
+
+define void @"Dictionary`2..ctor"(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  store %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  %0 = load %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, i32, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %0, i32 0, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* null)
+  ret void
+}
+
 INFO:  jitting method Dictionary`2::TryGetValue using LLILCJit
 Failed to read Dictionary`2.TryGetValue[loadElemA]
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
 Failed to read Dictionary`2.FindEntry[non-const derefAddress]
 INFO:  jitting method Path::NormalizePath using LLILCJit
-Failed to read Path.NormalizePath[Tail call]
+Successfully read Path.NormalizePath
+
+define %System.String addrspace(1)* @Path.NormalizePath(%System.String addrspace(1)* %param0, i8 %param1, i32 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = load i32, i32* %arg2
+  %4 = trunc i32 %2 to i8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, i8, i32, i8)*)(%System.String addrspace(1)* %0, i8 %4, i32 %3, i8 1)
+  ret %System.String addrspace(1)* %5
+}
+
 INFO:  jitting method StringBuilder::.ctor using LLILCJit
-Failed to read StringBuilder..ctor[Tail call]
+Successfully read StringBuilder..ctor
+
+define void @StringBuilder..ctor(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %this
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  br label %9
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %7 = getelementptr inbounds %System.String, %System.String addrspace(1)* %6, i32 0, i32 1
+  %8 = load i32, i32 addrspace(1)* %7
+  br label %9
+
+; <label>:9                                       ; preds = %4, %5
+  %10 = phi %System.Text.StringBuilder addrspace(1)* [ %0, %4 ], [ %0, %5 ]
+  %11 = phi %System.String addrspace(1)* [ %1, %4 ], [ %1, %5 ]
+  %12 = phi i32 [ 0, %4 ], [ 0, %5 ]
+  %13 = phi i32 [ 0, %4 ], [ %8, %5 ]
+  %14 = load i32, i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, %System.String addrspace(1)*, i32, i32, i32)*)(%System.Text.StringBuilder addrspace(1)* %10, %System.String addrspace(1)* %11, i32 %12, i32 %13, i32 %14)
+  ret void
+}
+
 INFO:  jitting method HashHelpers::ExpandPrime using LLILCJit
-Failed to read HashHelpers.ExpandPrime[Tail call]
+Successfully read HashHelpers.ExpandPrime
+
+define i32 @HashHelpers.ExpandPrime(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  %loc0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32, i32* %arg0
+  %1 = mul i32 2, %0
+  store i32 %1, i32* %loc0
+  %2 = load i32, i32* %loc0
+  %3 = icmp ule i32 %2, 2146435069
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32, i32* %arg0
+  %6 = icmp sle i32 2146435069, %5
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i32 2146435069
+
+; <label>:8                                       ; preds = %entry, %4
+  %9 = load i32, i32* %loc0
+  %10 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32)*)(i32 %9)
+  ret i32 %10
+}
+
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -2778,11 +5286,95 @@ entry:
 }
 
 INFO:  jitting method String::Equals using LLILCJit
-Failed to read String.Equals[Tail call]
+Successfully read String.Equals
+
+define i8 @String.Equals(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %4, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = call %System.NullReferenceException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.NullReferenceException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.NullReferenceException addrspace(1)*)*)(%System.NullReferenceException addrspace(1)* %3) #0
+  unreachable
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %6 = icmp ne %System.String addrspace(1)* %5, null
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %4
+  ret i8 0
+
+; <label>:8                                       ; preds = %4
+  %9 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %11 = bitcast %System.String addrspace(1)* %9 to %System.Object addrspace(1)*
+  %12 = bitcast %System.String addrspace(1)* %10 to %System.Object addrspace(1)*
+  %13 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.Object addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %11, %System.Object addrspace(1)* %12)
+  %14 = zext i8 %13 to i32
+  %15 = icmp eq i32 %14, 0
+  br i1 %15, label %17, label %16
+
+; <label>:16                                      ; preds = %8
+  ret i8 1
+
+; <label>:17                                      ; preds = %8
+  %18 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %19 = getelementptr inbounds %System.String, %System.String addrspace(1)* %18, i32 0, i32 1
+  %20 = load i32, i32 addrspace(1)* %19
+  %21 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.String, %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32, i32 addrspace(1)* %22
+  %24 = icmp eq i32 %20, %23
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %17
+  ret i8 0
+
+; <label>:26                                      ; preds = %17
+  %27 = load %System.String addrspace(1)*, %System.String addrspace(1)** %this
+  %28 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %29 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %27, %System.String addrspace(1)* %28)
+  %30 = zext i8 %29 to i32
+  %31 = trunc i32 %30 to i8
+  ret i8 %31
+}
+
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
 Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
-Failed to read AppDomain.SetupBindingPaths[Tail call]
+Successfully read AppDomain.SetupBindingPaths
+
+define void @AppDomain.SetupBindingPaths(%System.AppDomain addrspace(1)* %param0, %System.String addrspace(1)* %param1, %System.String addrspace(1)* %param2, %System.String addrspace(1)* %param3, %System.String addrspace(1)* %param4, %System.String addrspace(1)* %param5) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca %System.String addrspace(1)*
+  %arg3 = alloca %System.String addrspace(1)*
+  %arg4 = alloca %System.String addrspace(1)*
+  %arg5 = alloca %System.String addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %param2, %System.String addrspace(1)** %arg2
+  store %System.String addrspace(1)* %param3, %System.String addrspace(1)** %arg3
+  store %System.String addrspace(1)* %param4, %System.String addrspace(1)** %arg4
+  store %System.String addrspace(1)* %param5, %System.String addrspace(1)** %arg5
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg2
+  %2 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg3
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg4
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg5
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %0, %System.String addrspace(1)* %1, %System.String addrspace(1)* %2, %System.String addrspace(1)* %3, %System.String addrspace(1)* %4)
+  ret void
+}
+
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
@@ -2865,7 +5457,84 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeCompatibilityFlags using LLILCJit
-Failed to read AppDomain.InitializeCompatibilityFlags[Tail call]
+Successfully read AppDomain.InitializeCompatibilityFlags
+
+define void @AppDomain.InitializeCompatibilityFlags(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  %loc0 = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %1 = call %System.AppDomainSetup addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainSetup addrspace(1)* (%System.AppDomain addrspace(1)*)*)(%System.AppDomain addrspace(1)* %0)
+  store %System.AppDomainSetup addrspace(1)* %1, %System.AppDomainSetup addrspace(1)** %loc0
+  %2 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck = icmp ne %System.AppDomainSetup addrspace(1)* %2, null
+  br i1 %NullCheck, label %3, label %ThrowNullRef
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %2)
+  %5 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %4, null
+  br i1 %5, label %17, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %8 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %loc0
+  %NullCheck2 = icmp ne %System.AppDomainSetup addrspace(1)* %8, null
+  br i1 %NullCheck2, label %9, label %ThrowNullRef1
+
+; <label>:9                                       ; preds = %6
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %8)
+  %11 = call %System.StringComparer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.StringComparer addrspace(1)* ()*)()
+  %12 = bitcast %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %10 to %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*
+  %13 = bitcast %System.StringComparer addrspace(1)* %11 to %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*
+  %14 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)*, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14, %"System.Collections.Generic.IDictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %12, %"System.Collections.Generic.IEqualityComparer`1[System.__Canon]" addrspace(1)* %13)
+  %15 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %14 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*
+  %16 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %7, i32 0, i32 14
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %16, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %15)
+  br label %17
+
+; <label>:17                                      ; preds = %3, %9
+  %18 = load %System.AppDomain addrspace(1)*, %System.AppDomain addrspace(1)** %this
+  %19 = getelementptr inbounds %System.AppDomain, %System.AppDomain addrspace(1)* %18, i32 0, i32 18
+  store i8 1, i8 addrspace(1)* %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %6
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::GetCompatibilityFlags using LLILCJit
+Successfully read AppDomainSetup.GetCompatibilityFlags
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* @AppDomainSetup.GetCompatibilityFlags(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 9
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* addrspace(1)* %1, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object]" addrspace(1)* %2
+}
+
+INFO:  jitting method StringComparer::get_OrdinalIgnoreCase using LLILCJit
+Successfully read StringComparer.get_OrdinalIgnoreCase
+
+define %System.StringComparer addrspace(1)* @StringComparer.get_OrdinalIgnoreCase() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 88)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 80
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.StringComparer addrspace(1)**
+  %3 = load %System.StringComparer addrspace(1)*, %System.StringComparer addrspace(1)** %2
+  ret %System.StringComparer addrspace(1)* %3
+}
+
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
 Failed to read Dictionary`2..ctor[non-const derefAddress]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
@@ -2892,7 +5561,95 @@ Failed to read Enumerator.MoveNext[loadElemA]
 INFO:  jitting method Enumerator::get_Current using LLILCJit
 Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
-Failed to read OrdinalComparer.GetHashCode[Tail call]
+Successfully read OrdinalComparer.GetHashCode
+
+define i32 @OrdinalComparer.GetHashCode(%System.OrdinalComparer addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.OrdinalComparer addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  store %System.OrdinalComparer addrspace(1)* %param0, %System.OrdinalComparer addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.OrdinalComparer addrspace(1)*, %System.OrdinalComparer addrspace(1)** %this
+  %7 = getelementptr inbounds %System.OrdinalComparer, %System.OrdinalComparer addrspace(1)* %6, i32 0, i32 1
+  %8 = load i8, i8 addrspace(1)* %7, align 8
+  %9 = zext i8 %8 to i32
+  %10 = icmp eq i32 %9, 0
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %13 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  ret i32 %13
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = bitcast %System.String addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
+  %18 = add i64 %17, 64
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = add i64 %20, 16
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = bitcast %System.String addrspace(1)* %15 to %System.Object addrspace(1)*
+  %25 = inttoptr i64 %23 to i32 (%System.Object addrspace(1)*)*
+  %26 = call i32 %25(%System.Object addrspace(1)* %24)
+  ret i32 %26
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.String addrspace(1)*, i8, i64)*)(%System.String addrspace(1)* %0, i8 0, i64 0)
+  ret i32 %1
+}
+
+INFO:  jitting method TextInfo::GetHashCodeOrdinalIgnoreCase using LLILCJit
+Successfully read TextInfo.GetHashCodeOrdinalIgnoreCase
+
+define i32 @TextInfo.GetHashCodeOrdinalIgnoreCase(%System.String addrspace(1)* %param0, i8 %param1, i64 %param2) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i64
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  store i64 %param2, i64* %arg2
+  %0 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = load i64, i64* %arg2
+  %NullCheck = icmp ne %System.Globalization.TextInfo addrspace(1)* %0, null
+  br i1 %NullCheck, label %5, label %ThrowNullRef
+
+; <label>:5                                       ; preds = %entry
+  %6 = trunc i32 %3 to i8
+  %7 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Globalization.TextInfo addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(%System.Globalization.TextInfo addrspace(1)* %0, %System.String addrspace(1)* %1, i8 %6, i64 %4)
+  ret i32 %7
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
 Successfully read TextInfo.get_Invariant
 
@@ -2986,7 +5743,48 @@ entry:
 }
 
 INFO:  jitting method TextInfo::GetCaseInsensitiveHashCode using LLILCJit
-Failed to read TextInfo.GetCaseInsensitiveHashCode[Tail call]
+Successfully read TextInfo.GetCaseInsensitiveHashCode
+
+define i32 @TextInfo.GetCaseInsensitiveHashCode(%System.Globalization.TextInfo addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2, i64 %param3) {
+entry:
+  %this = alloca %System.Globalization.TextInfo addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  %arg3 = alloca i64
+  store %System.Globalization.TextInfo addrspace(1)* %param0, %System.Globalization.TextInfo addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  store i64 %param3, i64* %arg3
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %6, i32 0, i32 6
+  %8 = load i64, i64 addrspace(1)* %7, align 8
+  %9 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %9, i32 0, i32 7
+  %11 = load i64, i64 addrspace(1)* %10, align 8
+  %12 = load %System.Globalization.TextInfo addrspace(1)*, %System.Globalization.TextInfo addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Globalization.TextInfo, %System.Globalization.TextInfo addrspace(1)* %12, i32 0, i32 4
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %13, align 8
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
+  %16 = load i8, i8* %arg2
+  %17 = zext i8 %16 to i32
+  %18 = load i64, i64* %arg3
+  %19 = trunc i32 %17 to i8
+  %20 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i64, i64, %System.String addrspace(1)*, %System.String addrspace(1)*, i8, i64)*)(i64 %8, i64 %11, %System.String addrspace(1)* %14, %System.String addrspace(1)* %15, i8 %19, i64 %18)
+  ret i32 %20
+}
+
 INFO:  jitting method Enumerator::Dispose using LLILCJit
 Successfully read Enumerator.Dispose
 
@@ -3167,7 +5965,7 @@ entry:
 }
 
 INFO:  jitting method AppDomain::InitializeDomainSecurity using LLILCJit
-Failed to read AppDomain.InitializeDomainSecurity[Tail call]
+Failed to read AppDomain.InitializeDomainSecurity[Return refany or value class]
 INFO:  jitting method AppDomainSetup::InternalGetApplicationTrust using LLILCJit
 Successfully read AppDomainSetup.InternalGetApplicationTrust
 
@@ -3198,9 +5996,254 @@ entry:
 }
 
 INFO:  jitting method NamedPermissionSet::GetBuiltInSet using LLILCJit
-Failed to read NamedPermissionSet.GetBuiltInSet[Tail call]
+Successfully read NamedPermissionSet.GetBuiltInSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.GetBuiltInSet(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %3, label %2
+
+; <label>:2                                       ; preds = %entry
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %5 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck = icmp ne %System.String addrspace(1)* %4, null
+  br i1 %NullCheck, label %6, label %ThrowNullRef
+
+; <label>:6                                       ; preds = %3
+  %7 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %4, %System.String addrspace(1)* %5)
+  %8 = zext i8 %7 to i32
+  %9 = icmp eq i32 %8, 0
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %6
+  %11 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %11
+
+; <label>:12                                      ; preds = %6
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck2 = icmp ne %System.String addrspace(1)* %13, null
+  br i1 %NullCheck2, label %15, label %ThrowNullRef1
+
+; <label>:15                                      ; preds = %12
+  %16 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %13, %System.String addrspace(1)* %14)
+  %17 = zext i8 %16 to i32
+  %18 = icmp eq i32 %17, 0
+  br i1 %18, label %21, label %19
+
+; <label>:19                                      ; preds = %15
+  %20 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %20
+
+; <label>:21                                      ; preds = %15
+  %22 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %23 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck4 = icmp ne %System.String addrspace(1)* %22, null
+  br i1 %NullCheck4, label %24, label %ThrowNullRef3
+
+; <label>:24                                      ; preds = %21
+  %25 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %22, %System.String addrspace(1)* %23)
+  %26 = zext i8 %25 to i32
+  %27 = icmp eq i32 %26, 0
+  br i1 %27, label %30, label %28
+
+; <label>:28                                      ; preds = %24
+  %29 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %29
+
+; <label>:30                                      ; preds = %24
+  %31 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck6 = icmp ne %System.String addrspace(1)* %31, null
+  br i1 %NullCheck6, label %33, label %ThrowNullRef5
+
+; <label>:33                                      ; preds = %30
+  %34 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %31, %System.String addrspace(1)* %32)
+  %35 = zext i8 %34 to i32
+  %36 = icmp eq i32 %35, 0
+  br i1 %36, label %39, label %37
+
+; <label>:37                                      ; preds = %33
+  %38 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %38
+
+; <label>:39                                      ; preds = %33
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %41 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %NullCheck8 = icmp ne %System.String addrspace(1)* %40, null
+  br i1 %NullCheck8, label %42, label %ThrowNullRef7
+
+; <label>:42                                      ; preds = %39
+  %43 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %40, %System.String addrspace(1)* %41)
+  %44 = zext i8 %43 to i32
+  %45 = icmp eq i32 %44, 0
+  br i1 %45, label %48, label %46
+
+; <label>:46                                      ; preds = %42
+  %47 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* ()*)()
+  ret %System.Security.PermissionSet addrspace(1)* %47
+
+; <label>:48                                      ; preds = %42
+  ret %System.Security.PermissionSet addrspace(1)* null
+
+ThrowNullRef:                                     ; preds = %3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %12
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %21
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %30
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %39
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method NamedPermissionSet::CreateFullTrustSet using LLILCJit
+Successfully read NamedPermissionSet.CreateFullTrustSet
+
+define %System.Security.PermissionSet addrspace(1)* @NamedPermissionSet.CreateFullTrustSet() {
+entry:
+  %0 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.PermissionSet addrspace(1)* %0, i32 1)
+  ret %System.Security.PermissionSet addrspace(1)* %0
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load i32, i32* %arg1
+  %2 = icmp ne i32 %1, 1
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %4, i8 1)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %10, label %8
+
+; <label>:8                                       ; preds = %5
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %9, i8 0)
+  ret void
+
+; <label>:10                                      ; preds = %5
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %11)
+  %13 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %13) #0
+  unreachable
+}
+
+INFO:  jitting method PermissionSet::.ctor using LLILCJit
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = bitcast %System.Security.PermissionSet addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %2)
+  %3 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %3, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %4
+  ret void
+}
+
+INFO:  jitting method PermissionSet::Reset using LLILCJit
+Successfully read PermissionSet.Reset
+
+define void @PermissionSet.Reset(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 0, i8 addrspace(1)* %1
+  %2 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %3 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %2, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %3
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %4, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %5, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 8
+  store i8 0, i8 addrspace(1)* %7
+  %8 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %9 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %8, i32 0, i32 9
+  store i8 0, i8 addrspace(1)* %9
+  %10 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %11 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %10, i32 0, i32 10
+  store i8 0, i8 addrspace(1)* %11
+  %12 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %12, i32 0, i32 11
+  store i8 0, i8 addrspace(1)* %13
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %15, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  ret void
+}
+
+INFO:  jitting method PermissionSet::SetUnrestricted using LLILCJit
+Successfully read PermissionSet.SetUnrestricted
+
+define void @PermissionSet.SetUnrestricted(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  %4 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %0, i32 0, i32 6
+  store i8 %3, i8 addrspace(1)* %4
+  %5 = load i8, i8* %arg1
+  %6 = zext i8 %5 to i32
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %11, label %8
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %10, %System.Security.Util.TokenBasedSet addrspace(1)* null)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %8
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::.ctor using LLILCJit
 Successfully read ApplicationTrust..ctor
 
@@ -3227,9 +6270,62 @@ entry:
 }
 
 INFO:  jitting method EvidenceBase::.ctor using LLILCJit
-Failed to read EvidenceBase..ctor[Tail call]
+Successfully read EvidenceBase..ctor
+
+define void @EvidenceBase..ctor(%System.Security.Policy.EvidenceBase addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.EvidenceBase addrspace(1)*
+  store %System.Security.Policy.EvidenceBase addrspace(1)* %param0, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %0 = load %System.Security.Policy.EvidenceBase addrspace(1)*, %System.Security.Policy.EvidenceBase addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.EvidenceBase addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method ApplicationTrust::InitDefaultGrantSet using LLILCJit
-Failed to read ApplicationTrust.InitDefaultGrantSet[Tail call]
+Successfully read ApplicationTrust.InitDefaultGrantSet
+
+define void @ApplicationTrust.InitDefaultGrantSet(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %1 = icmp ne %System.Security.PermissionSet addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = call %System.Security.Policy.PolicyStatement addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.PolicyStatement addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %8, %System.Security.PermissionSet addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %6, %System.Security.Policy.PolicyStatement addrspace(1)* %8)
+  ret void
+}
+
+INFO:  jitting method PolicyStatement::.ctor using LLILCJit
+Successfully read PolicyStatement..ctor
+
+define void @PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.PermissionSet addrspace(1)*, i32)*)(%System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.PermissionSet addrspace(1)* %1, i32 0)
+  ret void
+}
+
 INFO:  jitting method PolicyStatement::.ctor using LLILCJit
 Successfully read PolicyStatement..ctor
 
@@ -3305,7 +6401,177 @@ entry:
 }
 
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %loc0 = alloca i32
+  %loc1 = alloca %System.Object addrspace(1)*
+  %loc2 = alloca %System.Security.IPermission addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %2 = icmp ne %System.Security.PermissionSet addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %4)
+  ret void
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %7 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %8 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %7, i32 0, i32 6
+  %9 = load i8, i8 addrspace(1)* %8, align 8
+  %10 = zext i8 %9 to i32
+  %11 = trunc i32 %10 to i8
+  %12 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %6, i32 0, i32 6
+  store i8 %11, i8 addrspace(1)* %12
+  %13 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %14 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %15 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %14, i32 0, i32 9
+  %16 = load i8, i8 addrspace(1)* %15, align 8
+  %17 = zext i8 %16 to i32
+  %18 = trunc i32 %17 to i8
+  %19 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %13, i32 0, i32 9
+  store i8 %18, i8 addrspace(1)* %19
+  %20 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %21 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %22 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %21, i32 0, i32 10
+  %23 = load i8, i8 addrspace(1)* %22, align 8
+  %24 = zext i8 %23 to i32
+  %25 = trunc i32 %24 to i8
+  %26 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %20, i32 0, i32 10
+  store i8 %25, i8 addrspace(1)* %26
+  %27 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %28 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %29 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %28, i32 0, i32 11
+  %30 = load i8, i8 addrspace(1)* %29, align 8
+  %31 = zext i8 %30 to i32
+  %32 = trunc i32 %31 to i8
+  %33 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %27, i32 0, i32 11
+  store i8 %32, i8 addrspace(1)* %33
+  %34 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %35 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %36 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %35, i32 0, i32 8
+  %37 = load i8, i8 addrspace(1)* %36, align 8
+  %38 = zext i8 %37 to i32
+  %39 = trunc i32 %38 to i8
+  %40 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %34, i32 0, i32 8
+  store i8 %39, i8 addrspace(1)* %40
+  %41 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %42 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %41, i32 0, i32 1
+  %43 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %42, align 8
+  %44 = icmp eq %System.Security.Util.TokenBasedSet addrspace(1)* %43, null
+  br i1 %44, label %91, label %45
+
+; <label>:45                                      ; preds = %5
+  %46 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %47 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
+  %48 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %47, i32 0, i32 1
+  %49 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %48, align 8
+  %50 = call %System.Security.Util.TokenBasedSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Util.TokenBasedSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %50, %System.Security.Util.TokenBasedSet addrspace(1)* %49)
+  %51 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %46, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %51, %System.Security.Util.TokenBasedSet addrspace(1)* %50)
+  %52 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %53 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %52, i32 0, i32 1
+  %54 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %53, align 8
+  %NullCheck = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %54, null
+  br i1 %NullCheck, label %55, label %ThrowNullRef
+
+; <label>:55                                      ; preds = %45
+  %56 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %54)
+  store i32 %56, i32* %loc0
+  br label %83
+
+; <label>:57                                      ; preds = %88
+  %58 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %58, i32 0, i32 1
+  %60 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %59, align 8
+  %61 = load i32, i32* %loc0
+  %NullCheck4 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %60, null
+  br i1 %NullCheck4, label %62, label %ThrowNullRef3
+
+; <label>:62                                      ; preds = %57
+  %63 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Security.Util.TokenBasedSet addrspace(1)*, i32)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %60, i32 %61)
+  store %System.Object addrspace(1)* %63, %System.Object addrspace(1)** %loc1
+  %64 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %loc1
+  %65 = call %System.Security.IPermission addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.IPermission addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %64)
+  store %System.Security.IPermission addrspace(1)* %65, %System.Security.IPermission addrspace(1)** %loc2
+  %66 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %67 = icmp eq %System.Security.IPermission addrspace(1)* %66, null
+  br i1 %67, label %80, label %68
+
+; <label>:68                                      ; preds = %62
+  %69 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %70 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %69, i32 0, i32 1
+  %71 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %70, align 8
+  %72 = load i32, i32* %loc0
+  %73 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
+  %74 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck6 = icmp ne %System.Security.IPermission addrspace(1)* %73, null
+  br i1 %NullCheck6, label %75, label %ThrowNullRef5
+
+; <label>:75                                      ; preds = %68
+  %76 = inttoptr i64 %74 to %System.Security.IPermission addrspace(1)* (%System.Security.IPermission addrspace(1)*)*
+  %77 = call %System.Security.IPermission addrspace(1)* %76(%System.Security.IPermission addrspace(1)* %73)
+  %NullCheck8 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %71, null
+  br i1 %NullCheck8, label %78, label %ThrowNullRef7
+
+; <label>:78                                      ; preds = %75
+  %79 = bitcast %System.Security.IPermission addrspace(1)* %77 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Util.TokenBasedSet addrspace(1)*, i32, %System.Object addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %71, i32 %72, %System.Object addrspace(1)* %79)
+  br label %80
+
+; <label>:80                                      ; preds = %62, %78
+  %81 = load i32, i32* %loc0
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %loc0
+  br label %83
+
+; <label>:83                                      ; preds = %55, %80
+  %84 = load i32, i32* %loc0
+  %85 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Security.PermissionSet, %System.Security.PermissionSet addrspace(1)* %85, i32 0, i32 1
+  %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
+  %NullCheck2 = icmp ne %System.Security.Util.TokenBasedSet addrspace(1)* %87, null
+  br i1 %NullCheck2, label %88, label %ThrowNullRef1
+
+; <label>:88                                      ; preds = %83
+  %89 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Security.Util.TokenBasedSet addrspace(1)*)*)(%System.Security.Util.TokenBasedSet addrspace(1)* %87)
+  %90 = icmp sle i32 %84, %89
+  br i1 %90, label %57, label %91
+
+; <label>:91                                      ; preds = %5, %88
+  ret void
+
+ThrowNullRef:                                     ; preds = %45
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef1:                                    ; preds = %83
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef3:                                    ; preds = %57
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef5:                                    ; preds = %68
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef7:                                    ; preds = %75
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PolicyStatement::ValidProperties using LLILCJit
 Successfully read PolicyStatement.ValidProperties
 
@@ -3471,11 +6737,48 @@ Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[non-const derefAddress]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
-Failed to read PermissionSet..ctor[Tail call]
+Successfully read PermissionSet..ctor
+
+define void @PermissionSet..ctor(%System.Security.PermissionSet addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %0)
+  %1 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %1, i8 %4)
+  ret void
+}
+
 INFO:  jitting method Simple_Array_Test::Main using LLILCJit
 Failed to read Simple_Array_Test.Main[loadElem]
 INFO:  jitting method Console::WriteLine using LLILCJit
-Failed to read Console.WriteLine[Tail call]
+Successfully read Console.WriteLine
+
+define void @Console.WriteLine(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
+  %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
+  %3 = load i64, i64 addrspace(1)* %2
+  %4 = add i64 %3, 104
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5
+  %7 = add i64 %6, 8
+  %8 = inttoptr i64 %7 to i64*
+  %9 = load i64, i64* %8
+  %10 = inttoptr i64 %9 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
+  call void %10(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method Console::get_Out using LLILCJit
 Failed to read Console.get_Out[Call HasTypeArg]
 INFO:  jitting method Console::.cctor using LLILCJit
@@ -3492,7 +6795,43 @@ entry:
 INFO:  jitting method Console::EnsureInitialized using LLILCJit
 Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
-Failed to read Console.<get_Out>b__2[Tail call]
+Successfully read Console.<get_Out>b__2
+
+define %System.IO.TextWriter addrspace(1)* @"Console.<get_Out>b__2"() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  %1 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %0)
+  ret %System.IO.TextWriter addrspace(1)* %1
+}
+
+INFO:  jitting method Console::OpenStandardOutput using LLILCJit
+Successfully read Console.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @Console.OpenStandardOutput() {
+entry:
+  %0 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* ()*)()
+  ret %System.IO.Stream addrspace(1)* %0
+}
+
+INFO:  jitting method ConsolePal::OpenStandardOutput using LLILCJit
+Successfully read ConsolePal.OpenStandardOutput
+
+define %System.IO.Stream addrspace(1)* @ConsolePal.OpenStandardOutput() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 ()*)()
+  %1 = call %System.IO.Stream addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)* (i64, i32)*)(i64 %0, i32 2)
+  ret %System.IO.Stream addrspace(1)* %1
+}
+
+INFO:  jitting method ConsolePal::get_OutputHandle using LLILCJit
+Successfully read ConsolePal.get_OutputHandle
+
+define i64 @ConsolePal.get_OutputHandle() {
+entry:
+  %0 = call i64 inttoptr (i64 NORMALIZED_ADDRESS to i64 (i32)*)(i32 -11)
+  ret i64 %0
+}
+
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
@@ -3690,11 +7029,90 @@ entry:
 }
 
 INFO:  jitting method Stream::.ctor using LLILCJit
-Failed to read Stream..ctor[Tail call]
+Successfully read Stream..ctor
+
+define void @Stream..ctor(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %this
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %this
+  %1 = bitcast %System.IO.Stream addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method mincore::GetFileType using LLILCJit
-Failed to read mincore.GetFileType[Tail call]
+Successfully read mincore.GetFileType
+
+define i32 @mincore.GetFileType(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = load i64, i64* %arg0
+  %1 = call i16* inttoptr (i64 NORMALIZED_ADDRESS to i16* (i64)*)(i64 %0)
+  %2 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i16*)*)(i16* %1)
+  ret i32 %2
+}
+
+INFO:  jitting method IntPtr::op_Explicit using LLILCJit
+Successfully read IntPtr.op_Explicit
+
+define i16* @IntPtr.op_Explicit(i64 %param0) {
+entry:
+  %arg0 = alloca i64
+  store i64 %param0, i64* %arg0
+  %0 = addrspacecast i64* %arg0 to i64 addrspace(1)*
+  %1 = bitcast i64 addrspace(1)* %0 to i8 addrspace(1)*
+  %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
+  %3 = bitcast i8 addrspace(1)* %2 to i16* addrspace(1)*
+  %4 = load i16*, i16* addrspace(1)* %3, align 8
+  ret i16* %4
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Console::CreateOutputWriter using LLILCJit
-Failed to read Console.CreateOutputWriter[Tail call]
+Successfully read Console.CreateOutputWriter
+
+define %System.IO.TextWriter addrspace(1)* @Console.CreateOutputWriter(%System.IO.Stream addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.IO.Stream addrspace(1)*
+  store %System.IO.Stream addrspace(1)* %param0, %System.IO.Stream addrspace(1)** %arg0
+  %0 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1377)
+  %1 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.Stream addrspace(1)**)
+  %2 = icmp eq %System.IO.Stream addrspace(1)* %0, %1
+  br i1 %2, label %16, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg0
+  %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
+  %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
+  %9 = add i64 %8, 120
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = add i64 %11, 0
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = inttoptr i64 %14 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
+  call void %15(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
+  br label %18
+
+; <label>:16                                      ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1436)
+  %17 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)**)
+  br label %18
+
+; <label>:18                                      ; preds = %3, %16
+  %19 = phi %System.IO.StreamWriter addrspace(1)* [ %6, %3 ], [ %17, %16 ]
+  %20 = bitcast %System.IO.StreamWriter addrspace(1)* %19 to %System.IO.TextWriter addrspace(1)*
+  %21 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %20)
+  ret %System.IO.TextWriter addrspace(1)* %21
+}
+
 INFO:  jitting method Stream::.cctor using LLILCJit
 Successfully read Stream..cctor
 
@@ -3710,9 +7128,39 @@ entry:
 }
 
 INFO:  jitting method NullStream::.ctor using LLILCJit
-Failed to read NullStream..ctor[Tail call]
+Successfully read NullStream..ctor
+
+define void @NullStream..ctor(%"System.IO.Stream+NullStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.IO.Stream+NullStream" addrspace(1)*
+  store %"System.IO.Stream+NullStream" addrspace(1)* %param0, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %0 = load %"System.IO.Stream+NullStream" addrspace(1)*, %"System.IO.Stream+NullStream" addrspace(1)** %this
+  %1 = bitcast %"System.IO.Stream+NullStream" addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.Stream addrspace(1)*)*)(%System.IO.Stream addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method ConsolePal::get_OutputEncoding using LLILCJit
+Successfully read ConsolePal.get_OutputEncoding
+
+define %System.Text.Encoding addrspace(1)* @ConsolePal.get_OutputEncoding() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* (i32)*)(i32 %0)
+  ret %System.Text.Encoding addrspace(1)* %1
+}
+
 INFO:  jitting method mincore::GetConsoleOutputCP using LLILCJit
-Failed to read mincore.GetConsoleOutputCP[Tail call]
+Successfully read mincore.GetConsoleOutputCP
+
+define i32 @mincore.GetConsoleOutputCP() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  ret i32 %0
+}
+
+INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetEncoding using LLILCJit
 Successfully read ConsolePal.GetEncoding
 
@@ -3806,7 +7254,53 @@ entry:
 }
 
 INFO:  jitting method Hashtable::GetHash using LLILCJit
-Failed to read Hashtable.GetHash[Tail call]
+Successfully read Hashtable.GetHash
+
+define i32 @Hashtable.GetHash(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %0, i32 0, i32 4
+  %2 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %2, null
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %6 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %5, i32 0, i32 4
+  %7 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %6, align 8
+  %8 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %9 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %NullCheck = icmp ne %System.Collections.IEqualityComparer addrspace(1)* %7, null
+  br i1 %NullCheck, label %10, label %ThrowNullRef
+
+; <label>:10                                      ; preds = %4
+  %11 = inttoptr i64 %9 to i32 (%System.Collections.IEqualityComparer addrspace(1)*, %System.Object addrspace(1)*)*
+  %12 = call i32 %11(%System.Collections.IEqualityComparer addrspace(1)* %7, %System.Object addrspace(1)* %8)
+  ret i32 %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %15 = bitcast %System.Object addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
+  %17 = add i64 %16, 64
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load i64, i64* %18
+  %20 = add i64 %19, 16
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load i64, i64* %21
+  %23 = inttoptr i64 %22 to i32 (%System.Object addrspace(1)*)*
+  %24 = call i32 %23(%System.Object addrspace(1)* %14)
+  ret i32 %24
+
+ThrowNullRef:                                     ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method Int32::GetHashCode using LLILCJit
 Successfully read Int32.GetHashCode
 
@@ -3851,7 +7345,119 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
-Failed to read UTF8Encoding..ctor[Tail call]
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = load i8, i8* %arg1
+  %2 = zext i8 %1 to i32
+  %3 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %0, i8 %3, i8 0)
+  ret void
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Successfully read UTF8Encoding..ctor
+
+define void @UTF8Encoding..ctor(%System.Text.UTF8Encoding addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.Text.UTF8Encoding addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  store %System.Text.UTF8Encoding addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %1 = bitcast %System.Text.UTF8Encoding addrspace(1)* %0 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %1, i32 65001)
+  %2 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %3 = load i8, i8* %arg1
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  %6 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %2, i32 0, i32 7
+  store i8 %5, i8 addrspace(1)* %6
+  %7 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %8 = load i8, i8* %arg2
+  %9 = zext i8 %8 to i32
+  %10 = trunc i32 %9 to i8
+  %11 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %7, i32 0, i32 8
+  store i8 %10, i8 addrspace(1)* %11
+  %12 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %13 = getelementptr inbounds %System.Text.UTF8Encoding, %System.Text.UTF8Encoding addrspace(1)* %12, i32 0, i32 8
+  %14 = load i8, i8 addrspace(1)* %13, align 8
+  %15 = zext i8 %14 to i32
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %29, label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
+  %19 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 32
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = bitcast %System.Text.UTF8Encoding addrspace(1)* %18 to %System.Text.Encoding addrspace(1)*
+  %28 = inttoptr i64 %26 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %28(%System.Text.Encoding addrspace(1)* %27)
+  br label %29
+
+; <label>:29                                      ; preds = %entry, %17
+  ret void
+}
+
+INFO:  jitting method Encoding::.ctor using LLILCJit
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 6
+  store i8 1, i8 addrspace(1)* %1
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %3)
+  %4 = load i32, i32* %arg1
+  %5 = icmp sge i32 %4, 0
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %8 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8, %System.String addrspace(1)* %7)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %8) #0
+  unreachable
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %11 = load i32, i32* %arg1
+  %12 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %10, i32 0, i32 4
+  store i32 %11, i32 addrspace(1)* %12
+  %13 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %14 = bitcast %System.Text.Encoding addrspace(1)* %13 to i64 addrspace(1)*
+  %15 = load i64, i64 addrspace(1)* %14
+  %16 = add i64 %15, 64
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64, i64* %17
+  %19 = add i64 %18, 32
+  %20 = inttoptr i64 %19 to i64*
+  %21 = load i64, i64* %20
+  %22 = inttoptr i64 %21 to void (%System.Text.Encoding addrspace(1)*)*
+  call void %22(%System.Text.Encoding addrspace(1)* %13)
+  ret void
+}
+
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 
@@ -3898,11 +7504,99 @@ entry:
 INFO:  jitting method EncoderReplacementFallback::.ctor using LLILCJit
 Failed to read EncoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Char::IsSurrogate using LLILCJit
-Failed to read Char.IsSurrogate[Tail call]
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(%System.String addrspace(1)* %param0, i32 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load i32, i32* %arg1
+  %7 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %8 = getelementptr inbounds %System.String, %System.String addrspace(1)* %7, i32 0, i32 1
+  %9 = load i32, i32 addrspace(1)* %8
+  %10 = icmp ult i32 %6, %9
+  br i1 %10, label %14, label %11
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13, %System.String addrspace(1)* %12)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %13) #0
+  unreachable
+
+; <label>:14                                      ; preds = %5
+  %15 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
+  %16 = load i32, i32* %arg1
+  %17 = getelementptr inbounds %System.String, %System.String addrspace(1)* %15, i32 0, i32 2, i32 %16
+  %18 = load i16, i16 addrspace(1)* %17
+  %19 = zext i16 %18 to i32
+  %20 = trunc i32 %19 to i16
+  %21 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i16)*)(i16 %20)
+  %22 = zext i8 %21 to i32
+  %23 = trunc i32 %22 to i8
+  ret i8 %23
+}
+
+INFO:  jitting method Char::IsSurrogate using LLILCJit
+Successfully read Char.IsSurrogate
+
+define i8 @Char.IsSurrogate(i16 %param0) {
+entry:
+  %arg0 = alloca i16
+  store i16 %param0, i16* %arg0
+  %0 = load i16, i16* %arg0
+  %1 = zext i16 %0 to i32
+  %2 = icmp slt i32 %1, 55296
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i16, i16* %arg0
+  %5 = zext i16 %4 to i32
+  %6 = icmp sgt i32 %5, 57343
+  %7 = sext i1 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  %9 = sext i1 %8 to i32
+  %10 = trunc i32 %9 to i8
+  ret i8 %10
+
+; <label>:11                                      ; preds = %entry
+  ret i8 0
+}
+
 INFO:  jitting method DecoderReplacementFallback::.ctor using LLILCJit
 Failed to read DecoderReplacementFallback..ctor[storeElem]
 INFO:  jitting method Hashtable::Add using LLILCJit
-Failed to read Hashtable.Add[Tail call]
+Successfully read Hashtable.Add
+
+define void @Hashtable.Add(%System.Collections.Hashtable addrspace(1)* %param0, %System.Object addrspace(1)* %param1, %System.Object addrspace(1)* %param2) {
+entry:
+  %this = alloca %System.Collections.Hashtable addrspace(1)*
+  %arg1 = alloca %System.Object addrspace(1)*
+  %arg2 = alloca %System.Object addrspace(1)*
+  store %System.Collections.Hashtable addrspace(1)* %param0, %System.Collections.Hashtable addrspace(1)** %this
+  store %System.Object addrspace(1)* %param1, %System.Object addrspace(1)** %arg1
+  store %System.Object addrspace(1)* %param2, %System.Object addrspace(1)** %arg2
+  %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
+  %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
+  %2 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*, %System.Object addrspace(1)*, i8)*)(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1, %System.Object addrspace(1)* %2, i8 1)
+  ret void
+}
+
 INFO:  jitting method Hashtable::Insert using LLILCJit
 Failed to read Hashtable.Insert[loadElemA]
 INFO:  jitting method ConsoleEncoding::.ctor using LLILCJit
@@ -3925,7 +7619,17 @@ entry:
 }
 
 INFO:  jitting method Encoding::.ctor using LLILCJit
-Failed to read Encoding..ctor[Tail call]
+Successfully read Encoding..ctor
+
+define void @Encoding..ctor(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)*, i32)*)(%System.Text.Encoding addrspace(1)* %0, i32 0)
+  ret void
+}
+
 INFO:  jitting method Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read Encoding.SetDefaultFallbacks
 
@@ -3973,7 +7677,18 @@ entry:
 }
 
 INFO:  jitting method EncoderFallback::.ctor using LLILCJit
-Failed to read EncoderFallback..ctor[Tail call]
+Successfully read EncoderFallback..ctor
+
+define void @EncoderFallback..ctor(%System.Text.EncoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.EncoderFallback addrspace(1)*
+  store %System.Text.EncoderFallback addrspace(1)* %param0, %System.Text.EncoderFallback addrspace(1)** %this
+  %0 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method InternalDecoderBestFitFallback::.ctor using LLILCJit
 Successfully read InternalDecoderBestFitFallback..ctor
 
@@ -4000,9 +7715,117 @@ entry:
 }
 
 INFO:  jitting method DecoderFallback::.ctor using LLILCJit
-Failed to read DecoderFallback..ctor[Tail call]
+Successfully read DecoderFallback..ctor
+
+define void @DecoderFallback..ctor(%System.Text.DecoderFallback addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.DecoderFallback addrspace(1)*
+  store %System.Text.DecoderFallback addrspace(1)* %param0, %System.Text.DecoderFallback addrspace(1)** %this
+  %0 = load %System.Text.DecoderFallback addrspace(1)*, %System.Text.DecoderFallback addrspace(1)** %this
+  %1 = bitcast %System.Text.DecoderFallback addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
 INFO:  jitting method StreamWriter::.ctor using LLILCJit
-Failed to read StreamWriter..ctor[Tail call]
+Successfully read StreamWriter..ctor
+
+define void @StreamWriter..ctor(%System.IO.StreamWriter addrspace(1)* %param0, %System.IO.Stream addrspace(1)* %param1, %System.Text.Encoding addrspace(1)* %param2, i32 %param3, i8 %param4) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %System.IO.Stream addrspace(1)*
+  %arg2 = alloca %System.Text.Encoding addrspace(1)*
+  %arg3 = alloca i32
+  %arg4 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %System.IO.Stream addrspace(1)* %param1, %System.IO.Stream addrspace(1)** %arg1
+  store %System.Text.Encoding addrspace(1)* %param2, %System.Text.Encoding addrspace(1)** %arg2
+  store i32 %param3, i32* %arg3
+  store i8 %param4, i8* %arg4
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = bitcast %System.IO.StreamWriter addrspace(1)* %0 to %System.IO.TextWriter addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.TextWriter addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.IO.TextWriter addrspace(1)* %1, %System.IFormatProvider addrspace(1)* null)
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %3 = icmp eq %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %7, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %6 = icmp ne %System.Text.Encoding addrspace(1)* %5, null
+  br i1 %6, label %17, label %7
+
+; <label>:7                                       ; preds = %entry, %4
+  %8 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %9 = icmp eq %System.IO.Stream addrspace(1)* %8, null
+  br i1 %9, label %12, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:12                                      ; preds = %7
+  %13 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %14
+
+; <label>:14                                      ; preds = %10, %12
+  %15 = phi %System.String addrspace(1)* [ %11, %10 ], [ %13, %12 ]
+  %16 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %4
+  %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
+  %20 = load i64, i64 addrspace(1)* %19
+  %21 = add i64 %20, 64
+  %22 = inttoptr i64 %21 to i64*
+  %23 = load i64, i64* %22
+  %24 = add i64 %23, 56
+  %25 = inttoptr i64 %24 to i64*
+  %26 = load i64, i64* %25
+  %27 = inttoptr i64 %26 to i8 (%System.IO.Stream addrspace(1)*)*
+  %28 = call i8 %27(%System.IO.Stream addrspace(1)* %18)
+  %29 = zext i8 %28 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %35, label %31
+
+; <label>:31                                      ; preds = %17
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %32)
+  %34 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34, %System.String addrspace(1)* %33)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %34) #0
+  unreachable
+
+; <label>:35                                      ; preds = %17
+  %36 = load i32, i32* %arg3
+  %37 = icmp sgt i32 %36, 0
+  br i1 %37, label %43, label %38
+
+; <label>:38                                      ; preds = %35
+  %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %41 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %40)
+  %42 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42, %System.String addrspace(1)* %39, %System.String addrspace(1)* %41)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %42) #0
+  unreachable
+
+; <label>:43                                      ; preds = %35
+  %44 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %45 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
+  %46 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg2
+  %47 = load i32, i32* %arg3
+  %48 = load i8, i8* %arg4
+  %49 = zext i8 %48 to i32
+  %50 = trunc i32 %49 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %44, %System.IO.Stream addrspace(1)* %45, %System.Text.Encoding addrspace(1)* %46, i32 %47, i8 %50)
+  ret void
+}
+
+INFO:  jitting method TextWriter::.ctor using LLILCJit
+Failed to read TextWriter..ctor[storeElem]
 INFO:  jitting method ConsoleStream::get_CanWrite using LLILCJit
 Successfully read ConsoleStream.get_CanWrite
 
@@ -4148,7 +7971,28 @@ entry:
 }
 
 INFO:  jitting method ConsoleEncoding::GetEncoder using LLILCJit
-Failed to read ConsoleEncoding.GetEncoder[Tail call]
+Successfully read ConsoleEncoding.GetEncoder
+
+define %System.Text.Encoder addrspace(1)* @ConsoleEncoding.GetEncoder(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %4 = load i64, i64 addrspace(1)* %3
+  %5 = add i64 %4, 96
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load i64, i64* %6
+  %8 = add i64 %7, 8
+  %9 = inttoptr i64 %8 to i64*
+  %10 = load i64, i64* %9
+  %11 = inttoptr i64 %10 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %12 = call %System.Text.Encoder addrspace(1)* %11(%System.Text.Encoding addrspace(1)* %2)
+  ret %System.Text.Encoder addrspace(1)* %12
+}
+
 INFO:  jitting method UTF8Encoding::GetEncoder using LLILCJit
 Successfully read UTF8Encoding.GetEncoder
 
@@ -4164,11 +8008,156 @@ entry:
 }
 
 INFO:  jitting method UTF8Encoder::.ctor using LLILCJit
-Failed to read UTF8Encoder..ctor[Tail call]
+Successfully read UTF8Encoder..ctor
+
+define void @UTF8Encoder..ctor(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %System.Text.UTF8Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  %arg1 = alloca %System.Text.UTF8Encoding addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  store %System.Text.UTF8Encoding addrspace(1)* %param1, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %arg1
+  %2 = bitcast %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0 to %System.Text.EncoderNLS addrspace(1)*
+  %3 = bitcast %System.Text.UTF8Encoding addrspace(1)* %1 to %System.Text.Encoding addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderNLS addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.EncoderNLS addrspace(1)* %2, %System.Text.Encoding addrspace(1)* %3)
+  ret void
+}
+
+INFO:  jitting method EncoderNLS::.ctor using LLILCJit
+Successfully read EncoderNLS..ctor
+
+define void @EncoderNLS..ctor(%System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.Encoding addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store %System.Text.Encoding addrspace(1)* %param1, %System.Text.Encoding addrspace(1)** %arg1
+  %0 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %1 = bitcast %System.Text.EncoderNLS addrspace(1)* %0 to %System.Text.Encoder addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoder addrspace(1)*)*)(%System.Text.Encoder addrspace(1)* %1)
+  %2 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %2, i32 0, i32 3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.Encoding addrspace(1)* addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %3)
+  %5 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %6 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %7 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 3
+  %8 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %7, align 8
+  %NullCheck = icmp ne %System.Text.Encoding addrspace(1)* %8, null
+  br i1 %NullCheck, label %9, label %ThrowNullRef
+
+; <label>:9                                       ; preds = %entry
+  %10 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %8)
+  %11 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %11, %System.Text.EncoderFallback addrspace(1)* %10)
+  %12 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %13 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to i64 addrspace(1)*
+  %14 = load i64, i64 addrspace(1)* %13
+  %15 = add i64 %14, 64
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = add i64 %17, 32
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19
+  %21 = bitcast %System.Text.EncoderNLS addrspace(1)* %12 to %System.Text.Encoder addrspace(1)*
+  %22 = inttoptr i64 %20 to void (%System.Text.Encoder addrspace(1)*)*
+  call void %22(%System.Text.Encoder addrspace(1)* %21)
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method Encoder::.ctor using LLILCJit
+Successfully read Encoder..ctor
+
+define void @Encoder..ctor(%System.Text.Encoder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoder addrspace(1)*
+  store %System.Text.Encoder addrspace(1)* %param0, %System.Text.Encoder addrspace(1)** %this
+  %0 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)** %this
+  %1 = bitcast %System.Text.Encoder addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  ret void
+}
+
+INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
+Successfully read Encoding.get_EncoderFallback
+
+define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.Encoding addrspace(1)*
+  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
+  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
+  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
+  ret %System.Text.EncoderFallback addrspace(1)* %2
+}
+
 INFO:  jitting method UTF8Encoder::Reset using LLILCJit
-Failed to read UTF8Encoder.Reset[Tail call]
+Successfully read UTF8Encoder.Reset
+
+define void @UTF8Encoder.Reset(%"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*
+  store %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %param0, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %0 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %0, i32 0, i32 8
+  store i32 0, i32 addrspace(1)* %1
+  %2 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %3 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %2, i32 0, i32 2
+  %4 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %3, align 8
+  %5 = icmp eq %System.Text.EncoderFallbackBuffer addrspace(1)* %4, null
+  br i1 %5, label %19, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = load %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)*, %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)** %this
+  %8 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %7, i32 0, i32 2
+  %9 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %8, align 8
+  %10 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
+  %12 = add i64 %11, 72
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64, i64* %13
+  %15 = add i64 %14, 8
+  %16 = inttoptr i64 %15 to i64*
+  %17 = load i64, i64* %16
+  %18 = inttoptr i64 %17 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
+  call void %18(%System.Text.EncoderFallbackBuffer addrspace(1)* %9)
+  br label %19
+
+; <label>:19                                      ; preds = %entry, %6
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetMaxByteCount using LLILCJit
-Failed to read ConsoleEncoding.GetMaxByteCount[Tail call]
+Successfully read ConsoleEncoding.GetMaxByteCount
+
+define i32 @ConsoleEncoding.GetMaxByteCount(%System.Text.ConsoleEncoding addrspace(1)* %param0, i32 %param1) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  %arg1 = alloca i32
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  %0 = load %System.Text.ConsoleEncoding addrspace(1)*, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
+  %2 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %1, align 8
+  %3 = load i32, i32* %arg1
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %2 to i64 addrspace(1)*
+  %5 = load i64, i64 addrspace(1)* %4
+  %6 = add i64 %5, 96
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = add i64 %8, 16
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64, i64* %10
+  %12 = inttoptr i64 %11 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
+  %13 = call i32 %12(%System.Text.Encoding addrspace(1)* %2, i32 %3)
+  ret i32 %13
+}
+
 INFO:  jitting method UTF8Encoding::GetMaxByteCount using LLILCJit
 Successfully read UTF8Encoding.GetMaxByteCount
 
@@ -4256,19 +8245,6 @@ entry:
   ret i32 %54
 }
 
-INFO:  jitting method Encoding::get_EncoderFallback using LLILCJit
-Successfully read Encoding.get_EncoderFallback
-
-define %System.Text.EncoderFallback addrspace(1)* @Encoding.get_EncoderFallback(%System.Text.Encoding addrspace(1)* %param0) {
-entry:
-  %this = alloca %System.Text.Encoding addrspace(1)*
-  store %System.Text.Encoding addrspace(1)* %param0, %System.Text.Encoding addrspace(1)** %this
-  %0 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %1 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %0, i32 0, i32 2
-  %2 = load %System.Text.EncoderFallback addrspace(1)*, %System.Text.EncoderFallback addrspace(1)* addrspace(1)* %1, align 8
-  ret %System.Text.EncoderFallback addrspace(1)* %2
-}
-
 INFO:  jitting method EncoderReplacementFallback::get_MaxCharCount using LLILCJit
 Successfully read EncoderReplacementFallback.get_MaxCharCount
 
@@ -4295,7 +8271,36 @@ entry:
 }
 
 INFO:  jitting method StreamWriter::set_AutoFlush using LLILCJit
-Failed to read StreamWriter.set_AutoFlush[Tail call]
+Successfully read StreamWriter.set_AutoFlush
+
+define void @StreamWriter.set_AutoFlush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %0)
+  %1 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %2 = load i8, i8* %arg1
+  %3 = zext i8 %2 to i32
+  %4 = trunc i32 %3 to i8
+  %5 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %1, i32 0, i32 11
+  store i8 %4, i8 addrspace(1)* %5
+  %6 = load i8, i8* %arg1
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %10, i8 1, i8 0)
+  br label %11
+
+; <label>:11                                      ; preds = %entry, %9
+  ret void
+}
+
 INFO:  jitting method StreamWriter::CheckAsyncTaskInProgress using LLILCJit
 Successfully read StreamWriter.CheckAsyncTaskInProgress
 
@@ -4340,7 +8345,206 @@ ThrowNullRef:                                     ; preds = %5
 }
 
 INFO:  jitting method StreamWriter::Flush using LLILCJit
-Failed to read StreamWriter.Flush[Tail call]
+Successfully read StreamWriter.Flush
+
+define void @StreamWriter.Flush(%System.IO.StreamWriter addrspace(1)* %param0, i8 %param1, i8 %param2) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca i8
+  %arg2 = alloca i8
+  %loc0 = alloca %"System.Byte[]" addrspace(1)*
+  %loc1 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store i8 %param1, i8* %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %1 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.IO.Stream addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)()
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %7 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %6, i32 0, i32 9
+  %8 = load i32, i32 addrspace(1)* %7, align 8
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %23, label %10
+
+; <label>:10                                      ; preds = %5
+  %11 = load i8, i8* %arg1
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %18, label %14
+
+; <label>:14                                      ; preds = %10
+  %15 = load i8, i8* %arg2
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %22, label %18
+
+; <label>:18                                      ; preds = %10, %14
+  %19 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %20 = zext i8 %19 to i32
+  %21 = icmp eq i32 %20, 0
+  br i1 %21, label %23, label %22
+
+; <label>:22                                      ; preds = %14, %18
+  ret void
+
+; <label>:23                                      ; preds = %5, %18
+  %24 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %25 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %24, i32 0, i32 12
+  %26 = load i8, i8 addrspace(1)* %25, align 8
+  %27 = zext i8 %26 to i32
+  %28 = icmp ne i32 %27, 0
+  br i1 %28, label %70, label %29
+
+; <label>:29                                      ; preds = %23
+  %30 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %31 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %30, i32 0, i32 12
+  store i8 1, i8 addrspace(1)* %31
+  %32 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %33 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %32, i32 0, i32 4
+  %34 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %33, align 8
+  %35 = bitcast %System.Text.Encoding addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
+  %37 = add i64 %36, 64
+  %38 = inttoptr i64 %37 to i64*
+  %39 = load i64, i64* %38
+  %40 = add i64 %39, 40
+  %41 = inttoptr i64 %40 to i64*
+  %42 = load i64, i64* %41
+  %43 = inttoptr i64 %42 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
+  %44 = call %"System.Byte[]" addrspace(1)* %43(%System.Text.Encoding addrspace(1)* %34)
+  store %"System.Byte[]" addrspace(1)* %44, %"System.Byte[]" addrspace(1)** %loc0
+  %45 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %46 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %45, i32 0, i32 1
+  %47 = load i32, i32 addrspace(1)* %46
+  %48 = zext i32 %47 to i64
+  %49 = trunc i64 %48 to i32
+  %50 = icmp sle i32 %49, 0
+  br i1 %50, label %70, label %51
+
+; <label>:51                                      ; preds = %29
+  %52 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %53 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %52, i32 0, i32 3
+  %54 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %53, align 8
+  %55 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %56 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %loc0
+  %57 = getelementptr inbounds %"System.Byte[]", %"System.Byte[]" addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32, i32 addrspace(1)* %57
+  %59 = zext i32 %58 to i64
+  %60 = trunc i64 %59 to i32
+  %61 = bitcast %System.IO.Stream addrspace(1)* %54 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
+  %63 = add i64 %62, 88
+  %64 = inttoptr i64 %63 to i64*
+  %65 = load i64, i64* %64
+  %66 = add i64 %65, 56
+  %67 = inttoptr i64 %66 to i64*
+  %68 = load i64, i64* %67
+  %69 = inttoptr i64 %68 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %69(%System.IO.Stream addrspace(1)* %54, %"System.Byte[]" addrspace(1)* %55, i32 0, i32 %60)
+  br label %70
+
+; <label>:70                                      ; preds = %23, %29, %51
+  %71 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %72 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %71, i32 0, i32 5
+  %73 = load %System.Text.Encoder addrspace(1)*, %System.Text.Encoder addrspace(1)* addrspace(1)* %72, align 8
+  %74 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %75 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %74, i32 0, i32 7
+  %76 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %75, align 8
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %80, i32 0, i32 6
+  %82 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %81, align 8
+  %83 = load i8, i8* %arg2
+  %84 = zext i8 %83 to i32
+  %85 = bitcast %System.Text.Encoder addrspace(1)* %73 to i64 addrspace(1)*
+  %86 = load i64, i64 addrspace(1)* %85
+  %87 = add i64 %86, 64
+  %88 = inttoptr i64 %87 to i64*
+  %89 = load i64, i64* %88
+  %90 = add i64 %89, 56
+  %91 = inttoptr i64 %90 to i64*
+  %92 = load i64, i64* %91
+  %93 = trunc i32 %84 to i8
+  %94 = inttoptr i64 %92 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
+  %95 = call i32 %94(%System.Text.Encoder addrspace(1)* %73, %"System.Char[]" addrspace(1)* %76, i32 0, i32 %79, %"System.Byte[]" addrspace(1)* %82, i32 0, i8 %93)
+  store i32 %95, i32* %loc1
+  %96 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %97 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %96, i32 0, i32 9
+  store i32 0, i32 addrspace(1)* %97
+  %98 = load i32, i32* %loc1
+  %99 = icmp sle i32 %98, 0
+  br i1 %99, label %117, label %100
+
+; <label>:100                                     ; preds = %70
+  %101 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %102 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %101, i32 0, i32 3
+  %103 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %102, align 8
+  %104 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %105 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %104, i32 0, i32 6
+  %106 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %105, align 8
+  %107 = load i32, i32* %loc1
+  %108 = bitcast %System.IO.Stream addrspace(1)* %103 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
+  %110 = add i64 %109, 88
+  %111 = inttoptr i64 %110 to i64*
+  %112 = load i64, i64* %111
+  %113 = add i64 %112, 56
+  %114 = inttoptr i64 %113 to i64*
+  %115 = load i64, i64* %114
+  %116 = inttoptr i64 %115 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
+  call void %116(%System.IO.Stream addrspace(1)* %103, %"System.Byte[]" addrspace(1)* %106, i32 0, i32 %107)
+  br label %117
+
+; <label>:117                                     ; preds = %70, %100
+  %118 = load i8, i8* %arg1
+  %119 = zext i8 %118 to i32
+  %120 = icmp eq i32 %119, 0
+  br i1 %120, label %134, label %121
+
+; <label>:121                                     ; preds = %117
+  %122 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %122, i32 0, i32 3
+  %124 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %123, align 8
+  %125 = bitcast %System.IO.Stream addrspace(1)* %124 to i64 addrspace(1)*
+  %126 = load i64, i64 addrspace(1)* %125
+  %127 = add i64 %126, 80
+  %128 = inttoptr i64 %127 to i64*
+  %129 = load i64, i64* %128
+  %130 = add i64 %129, 24
+  %131 = inttoptr i64 %130 to i64*
+  %132 = load i64, i64* %131
+  %133 = inttoptr i64 %132 to void (%System.IO.Stream addrspace(1)*)*
+  call void %133(%System.IO.Stream addrspace(1)* %124)
+  br label %134
+
+; <label>:134                                     ; preds = %117, %121
+  ret void
+}
+
+INFO:  jitting method CompatibilitySwitches::get_IsAppEarlierThanWindowsPhone8 using LLILCJit
+Successfully read CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8
+
+define i8 @CompatibilitySwitches.get_IsAppEarlierThanWindowsPhone8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 154)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1987
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8*
+  %3 = load i8, i8* %2
+  %4 = zext i8 %3 to i32
+  %5 = trunc i32 %4 to i8
+  ret i8 %5
+}
+
 INFO:  jitting method SyncTextWriter::GetSynchronizedTextWriter using LLILCJit
 Successfully read SyncTextWriter.GetSynchronizedTextWriter
 
@@ -4447,7 +8651,7 @@ ThrowNullRef:                                     ; preds = %4
 }
 
 INFO:  jitting method Thread::get_CurrentThread using LLILCJit
-Failed to read Thread.get_CurrentThread[Tail call]
+Failed to read Thread.get_CurrentThread[Call intrinsic]
 INFO:  jitting method Object::Finalize using LLILCJit
 Successfully read Object.Finalize
 
@@ -4499,7 +8703,52 @@ entry:
 }
 
 INFO:  jitting method Thread::get_CurrentCulture using LLILCJit
-Failed to read Thread.get_CurrentCulture[Tail call]
+Successfully read Thread.get_CurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.get_CurrentCulture(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 ()*)()
+  %1 = zext i8 %0 to i32
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %11, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %9, label %6
+
+; <label>:6                                       ; preds = %3
+  %7 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %8 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %7)
+  br label %9
+
+; <label>:9                                       ; preds = %3, %6
+  %10 = phi %System.Globalization.CultureInfo addrspace(1)* [ %4, %3 ], [ %8, %6 ]
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %entry
+  %12 = load %System.Threading.Thread addrspace(1)*, %System.Threading.Thread addrspace(1)** %this
+  %13 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.Threading.Thread addrspace(1)*)*)(%System.Threading.Thread addrspace(1)* %12)
+  ret %System.Globalization.CultureInfo addrspace(1)* %13
+}
+
+INFO:  jitting method AppDomain::IsAppXModel using LLILCJit
+Successfully read AppDomain.IsAppXModel
+
+define i8 @AppDomain.IsAppXModel() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %1 = and i32 %0, 2
+  %2 = icmp eq i32 %1, 0
+  %3 = sext i1 %2 to i32
+  %4 = icmp eq i32 %3, 0
+  %5 = sext i1 %4 to i32
+  %6 = trunc i32 %5 to i8
+  ret i8 %6
+}
+
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Successfully read AppDomain.get_Flags
 
@@ -4531,9 +8780,55 @@ entry:
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
-Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
-INFO:  jitting method TextWriter::.ctor using LLILCJit
-Failed to read TextWriter..ctor[storeElem]
+Successfully read Thread.GetCurrentCultureNoAppX
+
+define %System.Globalization.CultureInfo addrspace(1)* @Thread.GetCurrentCultureNoAppX(%System.Threading.Thread addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Threading.Thread addrspace(1)*
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  store %System.Threading.Thread addrspace(1)* %param0, %System.Threading.Thread addrspace(1)** %this
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 24
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %6, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %7 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %7, null
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %5
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  ret %System.Globalization.CultureInfo addrspace(1)* %10
+
+; <label>:11                                      ; preds = %5
+  %12 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 392)
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i64 24
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %16
+  ret %System.Globalization.CultureInfo addrspace(1)* %17
+}
+
+INFO:  jitting method CultureInfo::get_DefaultThreadCurrentCulture using LLILCJit
+Successfully read CultureInfo.get_DefaultThreadCurrentCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_DefaultThreadCurrentCulture() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 1744
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %2
+  ret %System.Globalization.CultureInfo addrspace(1)* %3
+}
+
 INFO:  jitting method SyncTextWriter::WriteLine using LLILCJit
 Successfully read SyncTextWriter.WriteLine
 
@@ -4588,20 +8883,208 @@ entry:
 }
 
 INFO:  jitting method TextWriter::WriteLine using LLILCJit
-Failed to read TextWriter.WriteLine[Tail call]
+Failed to read TextWriter.WriteLine[loadElem]
 INFO:  jitting method String::CopyTo using LLILCJit
 Failed to read String.CopyTo[loadElemA]
 INFO:  jitting method StreamWriter::Write using LLILCJit
-Failed to read StreamWriter.Write[Tail call]
+Successfully read StreamWriter.Write
+
+define void @StreamWriter.Write(%System.IO.StreamWriter addrspace(1)* %param0, %"System.Char[]" addrspace(1)* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.IO.StreamWriter addrspace(1)*
+  %arg1 = alloca %"System.Char[]" addrspace(1)*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i32
+  store %System.IO.StreamWriter addrspace(1)* %param0, %System.IO.StreamWriter addrspace(1)** %this
+  store %"System.Char[]" addrspace(1)* %param1, %"System.Char[]" addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %1 = icmp ne %"System.Char[]" addrspace(1)* %0, null
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32, i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32, i32* %arg3
+  %17 = icmp sge i32 %16, 0
+  br i1 %17, label %23, label %18
+
+; <label>:18                                      ; preds = %15
+  %19 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %21 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %20)
+  %22 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22, %System.String addrspace(1)* %19, %System.String addrspace(1)* %21)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %22) #0
+  unreachable
+
+; <label>:23                                      ; preds = %15
+  %24 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %25 = getelementptr inbounds %"System.Char[]", %"System.Char[]" addrspace(1)* %24, i32 0, i32 1
+  %26 = load i32, i32 addrspace(1)* %25
+  %27 = zext i32 %26 to i64
+  %28 = trunc i64 %27 to i32
+  %29 = load i32, i32* %arg2
+  %30 = sub i32 %28, %29
+  %31 = load i32, i32* %arg3
+  %32 = icmp sge i32 %30, %31
+  br i1 %32, label %37, label %33
+
+; <label>:33                                      ; preds = %23
+  %34 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %35 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %34)
+  %36 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36, %System.String addrspace(1)* %35)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %36) #0
+  unreachable
+
+; <label>:37                                      ; preds = %23
+  %38 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*)*)(%System.IO.StreamWriter addrspace(1)* %38)
+  br label %89
+
+; <label>:39                                      ; preds = %89
+  %40 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %41 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %40, i32 0, i32 9
+  %42 = load i32, i32 addrspace(1)* %41, align 8
+  %43 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %44 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %43, i32 0, i32 10
+  %45 = load i32, i32 addrspace(1)* %44, align 8
+  %46 = icmp ne i32 %42, %45
+  br i1 %46, label %49, label %47
+
+; <label>:47                                      ; preds = %39
+  %48 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %48, i8 0, i8 0)
+  br label %49
+
+; <label>:49                                      ; preds = %39, %47
+  %50 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %51 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %50, i32 0, i32 10
+  %52 = load i32, i32 addrspace(1)* %51, align 8
+  %53 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %54 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %53, i32 0, i32 9
+  %55 = load i32, i32 addrspace(1)* %54, align 8
+  %56 = sub i32 %52, %55
+  store i32 %56, i32* %loc0
+  %57 = load i32, i32* %loc0
+  %58 = load i32, i32* %arg3
+  %59 = icmp sle i32 %57, %58
+  br i1 %59, label %62, label %60
+
+; <label>:60                                      ; preds = %49
+  %61 = load i32, i32* %arg3
+  store i32 %61, i32* %loc0
+  br label %62
+
+; <label>:62                                      ; preds = %49, %60
+  %63 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)** %arg1
+  %64 = load i32, i32* %arg2
+  %65 = mul i32 %64, 2
+  %66 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %67 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %66, i32 0, i32 7
+  %68 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %67, align 8
+  %69 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %70 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %69, i32 0, i32 9
+  %71 = load i32, i32 addrspace(1)* %70, align 8
+  %72 = mul i32 %71, 2
+  %73 = load i32, i32* %loc0
+  %74 = mul i32 %73, 2
+  %75 = bitcast %"System.Char[]" addrspace(1)* %63 to %System.Array addrspace(1)*
+  %76 = bitcast %"System.Char[]" addrspace(1)* %68 to %System.Array addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Array addrspace(1)*, i32, %System.Array addrspace(1)*, i32, i32)*)(%System.Array addrspace(1)* %75, i32 %65, %System.Array addrspace(1)* %76, i32 %72, i32 %74)
+  %77 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %78 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  %79 = load i32, i32 addrspace(1)* %78, align 8
+  %80 = load i32, i32* %loc0
+  %81 = add i32 %79, %80
+  %82 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %77, i32 0, i32 9
+  store i32 %81, i32 addrspace(1)* %82
+  %83 = load i32, i32* %arg2
+  %84 = load i32, i32* %loc0
+  %85 = add i32 %83, %84
+  store i32 %85, i32* %arg2
+  %86 = load i32, i32* %arg3
+  %87 = load i32, i32* %loc0
+  %88 = sub i32 %86, %87
+  store i32 %88, i32* %arg3
+  br label %89
+
+; <label>:89                                      ; preds = %37, %62
+  %90 = load i32, i32* %arg3
+  %91 = icmp sgt i32 %90, 0
+  br i1 %91, label %39, label %92
+
+; <label>:92                                      ; preds = %89
+  %93 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  %94 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %93, i32 0, i32 11
+  %95 = load i8, i8 addrspace(1)* %94, align 8
+  %96 = zext i8 %95 to i32
+  %97 = icmp eq i32 %96, 0
+  br i1 %97, label %100, label %98
+
+; <label>:98                                      ; preds = %92
+  %99 = load %System.IO.StreamWriter addrspace(1)*, %System.IO.StreamWriter addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, i8, i8)*)(%System.IO.StreamWriter addrspace(1)* %99, i8 1, i8 0)
+  br label %100
+
+; <label>:100                                     ; preds = %92, %98
+  ret void
+}
+
 INFO:  jitting method ConsoleEncoding::GetPreamble using LLILCJit
-Failed to read ConsoleEncoding.GetPreamble[Tail call]
+Successfully read ConsoleEncoding.GetPreamble
+
+define %"System.Byte[]" addrspace(1)* @ConsoleEncoding.GetPreamble(%System.Text.ConsoleEncoding addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.ConsoleEncoding addrspace(1)*
+  store %System.Text.ConsoleEncoding addrspace(1)* %param0, %System.Text.ConsoleEncoding addrspace(1)** %this
+  %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* ()*)()
+  ret %"System.Byte[]" addrspace(1)* %0
+}
+
+INFO:  jitting method Array::Empty using LLILCJit
+Successfully read Array.Empty
+
+define %"System.Byte[]" addrspace(1)* @Array.Empty() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
+  %1 = getelementptr inbounds i8, i8 addrspace(1)* %0, i64 0
+  %2 = addrspacecast i8 addrspace(1)* %1 to %"System.Byte[]" addrspace(1)**
+  %3 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)** %2
+  ret %"System.Byte[]" addrspace(1)* %3
+}
+
 INFO:  jitting method EmptyArray`1::.cctor using LLILCJit
 Successfully read EmptyArray`1..cctor
 
 define void @"EmptyArray`1..cctor"() {
 entry:
   %0 = call %"System.Byte[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Byte[]" addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 0)
-  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 14)
+  %1 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 20)
   %2 = getelementptr inbounds i8, i8 addrspace(1)* %1, i64 0
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %"System.Byte[]" addrspace(1)*)*)(i8 addrspace(1)* %2, %"System.Byte[]" addrspace(1)* %0)
   ret void
@@ -4610,7 +9093,119 @@ entry:
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
 Failed to read EncoderNLS.GetBytes[loadElemA]
 INFO:  jitting method EncoderNLS::GetBytes using LLILCJit
-Failed to read EncoderNLS.GetBytes[Tail call]
+Successfully read EncoderNLS.GetBytes
+
+define i32 @EncoderNLS.GetBytes(%System.Text.EncoderNLS addrspace(1)* %param0, i16* %param1, i32 %param2, i8* %param3, i32 %param4, i8 %param5) {
+entry:
+  %this = alloca %System.Text.EncoderNLS addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i8*
+  %arg4 = alloca i32
+  %arg5 = alloca i8
+  store %System.Text.EncoderNLS addrspace(1)* %param0, %System.Text.EncoderNLS addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i8* %param3, i8** %arg3
+  store i32 %param4, i32* %arg4
+  store i8 %param5, i8* %arg5
+  %0 = load i16*, i16** %arg1
+  %1 = ptrtoint i16* %0 to i64
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %7, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = load i8*, i8** %arg3
+  %5 = ptrtoint i8* %4 to i64
+  %6 = icmp ne i64 %5, 0
+  br i1 %6, label %20, label %7
+
+; <label>:7                                       ; preds = %entry, %3
+  %8 = load i16*, i16** %arg1
+  %9 = ptrtoint i16* %8 to i64
+  %10 = icmp eq i64 %9, 0
+  br i1 %10, label %13, label %11
+
+; <label>:11                                      ; preds = %7
+  %12 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:13                                      ; preds = %7
+  %14 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %15
+
+; <label>:15                                      ; preds = %11, %13
+  %16 = phi %System.String addrspace(1)* [ %12, %11 ], [ %14, %13 ]
+  %17 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %18 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
+  %19 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19, %System.String addrspace(1)* %16, %System.String addrspace(1)* %18)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %19) #0
+  unreachable
+
+; <label>:20                                      ; preds = %3
+  %21 = load i32, i32* %arg4
+  %22 = icmp slt i32 %21, 0
+  br i1 %22, label %26, label %23
+
+; <label>:23                                      ; preds = %20
+  %24 = load i32, i32* %arg2
+  %25 = icmp sge i32 %24, 0
+  br i1 %25, label %38, label %26
+
+; <label>:26                                      ; preds = %20, %23
+  %27 = load i32, i32* %arg4
+  %28 = icmp slt i32 %27, 0
+  br i1 %28, label %31, label %29
+
+; <label>:29                                      ; preds = %26
+  %30 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:31                                      ; preds = %26
+  %32 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  br label %33
+
+; <label>:33                                      ; preds = %29, %31
+  %34 = phi %System.String addrspace(1)* [ %30, %29 ], [ %32, %31 ]
+  %35 = load %System.String addrspace(1)*, %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %35)
+  %37 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37, %System.String addrspace(1)* %34, %System.String addrspace(1)* %36)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %37) #0
+  unreachable
+
+; <label>:38                                      ; preds = %23
+  %39 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %40 = load i8, i8* %arg5
+  %41 = zext i8 %40 to i32
+  %42 = trunc i32 %41 to i8
+  %43 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %39, i32 0, i32 6
+  store i8 %42, i8 addrspace(1)* %43
+  %44 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %45 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %44, i32 0, i32 7
+  store i8 1, i8 addrspace(1)* %45
+  %46 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %47 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %46, i32 0, i32 3
+  %48 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %47, align 8
+  %49 = load i16*, i16** %arg1
+  %50 = load i32, i32* %arg2
+  %51 = load i8*, i8** %arg3
+  %52 = load i32, i32* %arg4
+  %53 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
+  %54 = bitcast %System.Text.Encoding addrspace(1)* %48 to i64 addrspace(1)*
+  %55 = load i64, i64 addrspace(1)* %54
+  %56 = add i64 %55, 80
+  %57 = inttoptr i64 %56 to i64*
+  %58 = load i64, i64* %57
+  %59 = add i64 %58, 32
+  %60 = inttoptr i64 %59 to i64*
+  %61 = load i64, i64* %60
+  %62 = inttoptr i64 %61 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
+  %63 = call i32 %62(%System.Text.Encoding addrspace(1)* %48, i16* %49, i32 %50, i8* %51, i32 %52, %System.Text.EncoderNLS addrspace(1)* %53)
+  ret i32 %63
+}
+
 INFO:  jitting method UTF8Encoding::GetBytes using LLILCJit
 Failed to read UTF8Encoding.GetBytes[storeElem]
 INFO:  jitting method WindowsConsoleStream::Write using LLILCJit
@@ -4749,5 +9344,62 @@ entry:
 INFO:  jitting method WindowsConsoleStream::WriteFileNative using LLILCJit
 Failed to read WindowsConsoleStream.WriteFileNative[loadElemA]
 INFO:  jitting method WindowsConsoleStream::Flush using LLILCJit
-Failed to read WindowsConsoleStream.Flush[Tail call]
+Successfully read WindowsConsoleStream.Flush
+
+define void @WindowsConsoleStream.Flush(%"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0) {
+entry:
+  %this = alloca %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*
+  store %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %param0, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %0 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %1 = getelementptr inbounds %"System.ConsolePal+WindowsConsoleStream", %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %0, i32 0, i32 7
+  %2 = load i64, i64 addrspace(1)* %1, align 8
+  %3 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i64, i64)*)(i64 %2, i64 0)
+  %4 = zext i8 %3 to i32
+  %5 = icmp eq i32 %4, 0
+  br i1 %5, label %8, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %7) #0
+  unreachable
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %"System.ConsolePal+WindowsConsoleStream" addrspace(1)*, %"System.ConsolePal+WindowsConsoleStream" addrspace(1)** %this
+  %10 = bitcast %"System.ConsolePal+WindowsConsoleStream" addrspace(1)* %9 to %System.IO.ConsoleStream addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.ConsoleStream addrspace(1)*)*)(%System.IO.ConsoleStream addrspace(1)* %10)
+  ret void
+}
+
+INFO:  jitting method ConsoleStream::Flush using LLILCJit
+Successfully read ConsoleStream.Flush
+
+define void @ConsoleStream.Flush(%System.IO.ConsoleStream addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.IO.ConsoleStream addrspace(1)*
+  store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
+  %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
+  %2 = load i64, i64 addrspace(1)* %1
+  %3 = add i64 %2, 64
+  %4 = inttoptr i64 %3 to i64*
+  %5 = load i64, i64* %4
+  %6 = add i64 %5, 56
+  %7 = inttoptr i64 %6 to i64*
+  %8 = load i64, i64* %7
+  %9 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
+  %10 = inttoptr i64 %8 to i8 (%System.IO.Stream addrspace(1)*)*
+  %11 = call i8 %10(%System.IO.Stream addrspace(1)* %9)
+  %12 = zext i8 %11 to i32
+  %13 = icmp ne i32 %12, 0
+  br i1 %13, label %16, label %14
+
+; <label>:14                                      ; preds = %entry
+  %15 = call %System.Exception addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Exception addrspace(1)* ()*)()
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Exception addrspace(1)*)*)(%System.Exception addrspace(1)* %15) #0
+  unreachable
+
+; <label>:16                                      ; preds = %entry
+  ret void
+}
+
 


### PR DESCRIPTION
If a tail call opportunity doesn't have the explicit `tail` prefix the jit can just generate a normal call. This turns all of our blocking tail call failures into successes or other failure types.

It also exposed an issue in storePrimitiveType where we'd widen i16 stores to i32. So I've fixed that too.

Rebased the tests since lots more methods now get handled. Typical pass rates are now above 60%
